### PR TITLE
Add support for multiple-domains with setDomainName

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Proudly brought to you by the [@revolunet](http://twitter.com/revolunet) team.
  - automatic page tracking
  - events tracking
  - e-commerce tracking
+ - multiple-domains
 
 ## example
 
@@ -21,7 +22,10 @@ var app = angular.module('app', ['angular-google-analytics'])
 
         // track all routes (or not)
         AnalyticsProvider.trackPages(true);
-        
+
+        //Optional set domain (Use 'none' for testing on localhost)
+        //AnalyticsProvider.setDomainName('XXX');
+
         // url prefix (default is empty)
         // - for example: when an app doesn't run in the root directory
         AnalyticsProvider.trackPrefix('my-application');
@@ -53,6 +57,9 @@ var app = angular.module('app', ['angular-google-analytics'])
 AnalyticsProvider.setAccount('UA-XXXXX-xx');
 // automatic route tracking (default=true)
 AnalyticsProvider.trackPages(false);
+//Optional set domain (Use 'none' for testing on localhost)
+AnalyticsProvider.setDomainName('XXX');
+
 ```
 
 ## Licence

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -7,7 +7,8 @@ angular.module('angular-google-analytics', [])
         var created = false,
             trackRoutes = true,
             accountId,
-            trackPrefix = '';
+            trackPrefix = ''',
+            domainName;
 
           this._logs = [];
 
@@ -25,6 +26,11 @@ angular.module('angular-google-analytics', [])
               return true;
           };
 
+          this.setDomainName = function(domain) {
+            domainName = domain;
+            return true;
+          };
+
         // public service
         this.$get = ['$document', '$rootScope', '$location', '$window', function($document, $rootScope, $location, $window) {
           // private methods
@@ -34,6 +40,7 @@ angular.module('angular-google-analytics', [])
             $window._gaq = [];
             $window._gaq.push(['_setAccount', accountId]);
             if (trackRoutes) $window._gaq.push(['_trackPageview']);
+            if(domainName) $window._gaq.push(['_setDomainName', domainName]);
             (function() {
               var document = $document[0];
               var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
Just added a simple setter on the configuration.
Details on tracking multiple domains:
https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSite

But the reason I needed it was to do some testing on localhost:
http://stackoverflow.com/questions/4375447/can-you-test-google-analytics-on-a-localhost-address
