### PR TITLE
Support arbitrary page event names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ var app = angular.module('app', ['angular-google-analytics'])
 
         // change filename to analytics.js
         AnalyticsProvider.setFilename('analytics.js);
+
+        // change page event name
+        AnalyticsProvider.setPageEvent('$stateChangeSuccess');
     }))
     .controller('SampleController', function(Analytics) {
         // create a new pageview event
@@ -65,6 +68,8 @@ AnalyticsProvider.trackPages(false);
 AnalyticsProvider.setDomainName('XXX');
 //Change default file from ga.js
 AnalyticsProvider.setFilename('analytics.js');
+//Change the default page event name. This is useful for ui-router, which fires $stateChangeSuccess instead of $routeChangeSuccess
+AnalyticsProvider.setPageEvent('$stateChangeSuccess');
 
 ```
 

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -9,7 +9,8 @@ angular.module('angular-google-analytics', [])
             accountId,
             trackPrefix = '',
             domainName,
-            filename = 'ga.js';
+            filename = 'ga.js',
+            pageEvent = '$routeChangeSuccess';
 
           this._logs = [];
 
@@ -34,6 +35,11 @@ angular.module('angular-google-analytics', [])
 
           this.setFilename = function(name) {
             filename = name;
+            return true;
+          };
+
+          this.setPageEvent = function(name) {
+            pageEvent = name;
             return true;
           };
 
@@ -128,7 +134,7 @@ angular.module('angular-google-analytics', [])
             var me = this;
 
             // activates page tracking
-            if (trackRoutes) $rootScope.$on('$routeChangeSuccess', function() {
+            if (trackRoutes) $rootScope.$on(pageEvent, function() {
               me._trackPage($location.path());
             });
 

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -90,6 +90,20 @@ describe('angular-google-analytics', function(){
 
   });
 
+  describe('supports arbitrary page events', function() {
+    beforeEach(module(function(AnalyticsProvider) {
+      AnalyticsProvider.setPageEvent('$stateChangeSuccess');
+    }));
+
+    it('should inject the Analytics script', function() {
+      inject(function(Analytics, $rootScope) {
+        $rootScope.$broadcast('$stateChangeSuccess');
+        expect(Analytics._logs.length).toBe(1);
+      });
+    });
+
+  });
+
 
 });
 


### PR DESCRIPTION
Angular-UI's ui-router fires $stateChangeSuccess instead of $routeChangeSuccess. With this modification, one could key off of an arbitrary $rootScope event for page tracking purposes.
