### PR TITLE
README update for automatic page tracking caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ var app = angular.module('app', ['angular-google-analytics'])
         // change page event name
         AnalyticsProvider.setPageEvent('$stateChangeSuccess');
     }))
+    .run(function(Analytics) {
+      // In case you are relying on automatic page tracking, you need to inject Analytics
+      // at least once in your application (for example in the main run() block)
+    })
     .controller('SampleController', function(Analytics) {
         // create a new pageview event
         Analytics.trackPage('/video/detail/XXX');


### PR DESCRIPTION
Thanks for providing this great Angular module. It saved me a lot of time.

One little caveat which took me a while to figure out is that `Analytics` needs to be injected at least once for the Google Analytics script to be loaded and the automatic page tracking event handler to be activated. As I was not going to use `Analytics` in any of my controllers, I had to inject it in the main `run()` block.

I've updated `README.md` with an example.
