### PR TITLE
Corrected syntax error in readme example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or alternatively, grab the dist/angular-google-analytics.min.js and include it i
 
 ```js
 var app = angular.module('app', ['angular-google-analytics'])
-    .config(function('AnalyticsProvider') {
+    .config(function(AnalyticsProvider) {
         // initial configuration
         AnalyticsProvider.setAccount('UA-XXXXX-xx');
 


### PR DESCRIPTION
Hey, love the repo! I just implemented your library into my project, and I realized there is a syntax error in the readme example code. I just removed the quotes from the config function definition, and now the example code should work!
