### PR TITLE
add optional page title parameter to trackPage() for dynamic page titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ var app = angular.module('app', ['angular-google-analytics'])
         // create a new pageview event
         Analytics.trackPage('/video/detail/XXX');
 
+        // or create a new pageview event with optional page title
+        Analytics.trackPage('/video/detail/XXX', 'Video XXX');
+
         // create a new tracking event
         Analytics.trackEvent('video', 'play', 'django.mp4');
         

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -157,7 +157,7 @@ angular.module('angular-google-analytics', [])
             this._logs.push(arguments);
           };
           this._trackPage = function(url, title) {
-            title = title ? title : document.title;
+            title = title ? title : $document[0].title;
             if (trackRoutes && !analyticsJS && $window._gaq) {
               // http://stackoverflow.com/questions/7322288/how-can-i-set-a-page-title-with-google-analytics
               $window._gaq.push(["_set", "title", title]);


### PR DESCRIPTION
Where page title is set dynamically, google grabs document.title before digest has finished updating the DOM, provide optional title parameter to trackPage() in this case
