### PR TITLE
add more options for multiple tracking objects

### DIFF
--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -204,6 +204,12 @@ angular.module('angular-google-analytics', [])
             } else {
               $window.ga('create', trackerObj.tracker, _cookieConfig, options);
             }
+            if (options && 'allowLinker' in options && options.allowLinker) {
+              $window.ga(_generateCommandName('require', trackerObj), 'linker');
+              if ('crossLinkDomains' in trackerObj) {
+                $window.ga(_generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
+              }
+            }
           });
         } else if (crossDomainLinker) {
           $window.ga('create', accountId, cookieConfig, linkerConfig);

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -169,7 +169,7 @@ angular.module('angular-google-analytics', [])
 
       function _generateCommandName(commandName, config) {
         if (!angular.isUndefined(config) && 'name' in config && config.name) {
-          return config.name+'.'+commandName;
+          return config.name + '.' + commandName;
         } else {
           return commandName;
         }

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -288,7 +288,8 @@ angular.module('angular-google-analytics', [])
         _analyticsJs(function () {
           if (angular.isArray(accountId)) {
             accountId.forEach(function (trackerObj) {
-              $window.ga(trackerObj.name + '.send', 'pageview', {
+              var sendCmd = 'name' in trackerObj ? trackerObj.name + '.send' : 'send';
+              $window.ga(sendCmd, 'pageview', {
                 'page': trackPrefix + url,
                 'title': title
               });

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -191,6 +191,9 @@ angular.module('angular-google-analytics', [])
           accountId.forEach(function (trackerObj) {
             var _cookieConfig = 'cookieConfig' in trackerObj ? trackerObj.cookieConfig : cookieConfig;
             var options;
+            if ('crossDomainLinker' in trackerObj && trackerObj.crossDomainLinker) {
+              trackerObj.allowLinker = trackerObj.crossDomainLinker;
+            }
             angular.forEach(['name', 'allowLinker'], function(key) {
               if (key in trackerObj) {
                 if (angular.isUndefined(options)) {

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -175,6 +175,10 @@ angular.module('angular-google-analytics', [])
         }
       }
 
+      function _checkOption(key, config) {
+        return key in config && config[key];
+      }
+
       function _createAnalyticsScriptTag() {
         if (!accountId) {
           me._log('warn', 'No account id set to create analytics script tag');
@@ -191,7 +195,7 @@ angular.module('angular-google-analytics', [])
           accountId.forEach(function (trackerObj) {
             var _cookieConfig = 'cookieConfig' in trackerObj ? trackerObj.cookieConfig : cookieConfig;
             var options;
-            if ('crossDomainLinker' in trackerObj && trackerObj.crossDomainLinker) {
+            if (_checkOption('crossDomainLinker', trackerObj)) {
               trackerObj.allowLinker = trackerObj.crossDomainLinker;
             }
             angular.forEach(['name', 'allowLinker'], function(key) {
@@ -209,7 +213,7 @@ angular.module('angular-google-analytics', [])
             }
             if (options && 'allowLinker' in options && options.allowLinker) {
               $window.ga(_generateCommandName('require', trackerObj), 'linker');
-              if ('crossLinkDomains' in trackerObj && trackerObj.crossLinkDomains) {
+              if (_checkOption('crossLinkDomains', trackerObj)) {
                 $window.ga(_generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
               }
             }
@@ -340,7 +344,7 @@ angular.module('angular-google-analytics', [])
         _analyticsJs(function () {
           if (angular.isArray(accountId)) {
             accountId.forEach(function (trackerObj) {
-              if ('trackEvent' in trackerObj && trackerObj.trackEvent) {
+              if (_checkOption('trackEvent', trackerObj)) {
                 $window.ga(_generateCommandName('send', trackerObj), 'event', category, action, label, value);
               }
             });

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -181,7 +181,8 @@ angular.module('angular-google-analytics', [])
 
         if (angular.isArray(accountId)) {
           accountId.forEach(function (trackerObj) {
-            $window.ga('create', trackerObj.tracker, cookieConfig, { name: trackerObj.name });
+            var _cookieConfig = 'cookieConfig' in trackerObj ? trackerObj.cookieConfig : cookieConfig;
+            $window.ga('create', trackerObj.tracker, _cookieConfig, { name: trackerObj.name });
           });
         } else if (crossDomainLinker) {
           $window.ga('create', accountId, cookieConfig, linkerConfig);

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -209,7 +209,7 @@ angular.module('angular-google-analytics', [])
             }
             if (options && 'allowLinker' in options && options.allowLinker) {
               $window.ga(_generateCommandName('require', trackerObj), 'linker');
-              if ('crossLinkDomains' in trackerObj) {
+              if ('crossLinkDomains' in trackerObj && trackerObj.crossLinkDomains) {
                 $window.ga(_generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
               }
             }

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -182,7 +182,20 @@ angular.module('angular-google-analytics', [])
         if (angular.isArray(accountId)) {
           accountId.forEach(function (trackerObj) {
             var _cookieConfig = 'cookieConfig' in trackerObj ? trackerObj.cookieConfig : cookieConfig;
-            $window.ga('create', trackerObj.tracker, _cookieConfig, { name: trackerObj.name });
+            var options = undefined;
+            angular.forEach(['name', 'allowLinker'], function(key) {
+              if (key in trackerObj) {
+                if (angular.isUndefined(options)) {
+                  options = {};
+                }
+                options[key] = trackerObj[key];
+              }
+            });
+            if (angular.isUndefined(options)) {
+              $window.ga('create', trackerObj.tracker, _cookieConfig);
+            } else {
+              $window.ga('create', trackerObj.tracker, _cookieConfig, options);
+            }
           });
         } else if (crossDomainLinker) {
           $window.ga('create', accountId, cookieConfig, linkerConfig);

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -167,6 +167,14 @@ angular.module('angular-google-analytics', [])
         created = true;
       }
 
+      function _generateCommandName(commandName, config) {
+        if (!angular.isUndefined(config) && 'name' in config && config.name) {
+          return config.name+'.'+commandName;
+        } else {
+          return commandName;
+        }
+      }
+
       function _createAnalyticsScriptTag() {
         if (!accountId) {
           me._log('warn', 'No account id set to create analytics script tag');

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -329,7 +329,15 @@ angular.module('angular-google-analytics', [])
           that._log('trackEvent', args);
         });
         _analyticsJs(function () {
-          $window.ga('send', 'event', category, action, label, value);
+          if (angular.isArray(accountId)) {
+            accountId.forEach(function (trackerObj) {
+              if ('trackEvent' in trackerObj && trackerObj.trackEvent) {
+                $window.ga(_generateCommandName('send', trackerObj), 'event', category, action, label, value);
+              }
+            });
+          } else {
+            $window.ga('send', 'event', category, action, label, value);
+          }
           that._log('event', args);
         });
       };

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -296,8 +296,7 @@ angular.module('angular-google-analytics', [])
         _analyticsJs(function () {
           if (angular.isArray(accountId)) {
             accountId.forEach(function (trackerObj) {
-              var sendCmd = 'name' in trackerObj ? trackerObj.name + '.send' : 'send';
-              $window.ga(sendCmd, 'pageview', {
+              $window.ga(_generateCommandName('send', trackerObj), 'pageview', {
                 'page': trackPrefix + url,
                 'title': title
               });

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -190,7 +190,7 @@ angular.module('angular-google-analytics', [])
         if (angular.isArray(accountId)) {
           accountId.forEach(function (trackerObj) {
             var _cookieConfig = 'cookieConfig' in trackerObj ? trackerObj.cookieConfig : cookieConfig;
-            var options = undefined;
+            var options;
             angular.forEach(['name', 'allowLinker'], function(key) {
               if (key in trackerObj) {
                 if (angular.isUndefined(options)) {

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -646,4 +646,74 @@ describe('angular-google-analytics', function () {
       });
     });
   });
+
+  describe('supports advanced options for multiple traking objects', function () {
+    var trackers = [
+      { tracker: 'UA-12345-12', name: "tracker1", crossDomainLinker: true },
+      { tracker: 'UA-12345-34', name: "tracker2", crossDomainLinker: true, crossLinkDomains: ['domain-1.com'] },
+      { tracker: 'UA-12345-45', crossDomainLinker: true, crossLinkDomains: ['domain-2.com'] },
+      { tracker: 'UA-12345-67', cookieConfig: 'yourdomain.org' }
+    ];
+
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.setAccount(trackers);
+      AnalyticsProvider.useAnalytics(true);
+    }));
+
+    it('should call ga require for each tracker', function () {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          expect($window.ga).toHaveBeenCalledWith('tracker1.require', 'linker');
+          expect($window.ga).toHaveBeenCalledWith('tracker2.require', 'linker');
+          expect($window.ga).toHaveBeenCalledWith('require', 'linker');
+        });
+      });
+    });
+
+    it('should call ga linker autoLink for configured tracking objects only', function () {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          expect($window.ga).not.toHaveBeenCalledWith('tracker1.linker:autoLink');
+          expect($window.ga).toHaveBeenCalledWith('tracker2.linker:autoLink', ['domain-1.com']);
+          expect($window.ga).toHaveBeenCalledWith('linker:autoLink', ['domain-2.com']);
+        });
+      });
+    });
+
+    it ('should call ga create with custom cookie config', function() {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          expect($window.ga).toHaveBeenCalledWith('create', 'UA-12345-67', 'yourdomain.org');
+        });
+      });
+    });
+  });
+
+  describe('supports advanced tracking for multiple tracking objects', function () {
+    var trackers = [
+      { tracker: 'UA-12345-12', name: "tracker1", trackEvent: true },
+      { tracker: 'UA-12345-34', name: "tracker2" },
+      { tracker: 'UA-12345-45', trackEvent: true }
+    ];
+
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.setAccount(trackers);
+      AnalyticsProvider.useAnalytics(true);
+    }));
+
+    it('should track events for configured tracking objects only', function () {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          Analytics.trackEvent('category', 'action', 'label', 'value');
+          expect($window.ga).toHaveBeenCalledWith('tracker1.send', 'event', 'category', 'action', 'label', 'value');
+          expect($window.ga).not.toHaveBeenCalledWith('tracker2.send', 'event', 'category', 'action', 'label', 'value');
+          expect($window.ga).toHaveBeenCalledWith('send', 'event', 'category', 'action', 'label', 'value');
+        });
+      });
+    });
+  });
 });

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -647,7 +647,7 @@ describe('angular-google-analytics', function () {
     });
   });
 
-  describe('supports advanced options for multiple traking objects', function () {
+  describe('supports advanced options for multiple tracking objects', function () {
     var trackers = [
       { tracker: 'UA-12345-12', name: "tracker1", crossDomainLinker: true },
       { tracker: 'UA-12345-34', name: "tracker2", crossDomainLinker: true, crossLinkDomains: ['domain-1.com'] },

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -612,7 +612,8 @@ describe('angular-google-analytics', function () {
   describe('supports multiple tracking objects', function () {
     var trackers = [
       { tracker: 'UA-12345-12', name: "tracker1" },
-      { tracker: 'UA-12345-34', name: "tracker2" }
+      { tracker: 'UA-12345-34', name: "tracker2" },
+      { tracker: 'UA-12345-45' }
     ];
 
     beforeEach(module(function (AnalyticsProvider) {
@@ -626,6 +627,7 @@ describe('angular-google-analytics', function () {
         inject(function (Analytics) {
           expect($window.ga).toHaveBeenCalledWith('create', trackers[0].tracker, 'auto', { name: trackers[0].name });
           expect($window.ga).toHaveBeenCalledWith('create', trackers[1].tracker, 'auto', { name: trackers[1].name });
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[2].tracker, 'auto');
         });
       });
     });
@@ -638,6 +640,7 @@ describe('angular-google-analytics', function () {
             Analytics.trackPage('/mypage', 'My Page');
             expect($window.ga).toHaveBeenCalledWith(trackers[0].name + '.send', 'pageview', { page: '/mypage', title: 'My Page' });
             expect($window.ga).toHaveBeenCalledWith(trackers[1].name + '.send', 'pageview', { page: '/mypage', title: 'My Page' });
+            expect($window.ga).toHaveBeenCalledWith('send', 'pageview', { page: '/mypage', title: 'My Page' });
           });
         });
       });


### PR DESCRIPTION
Hi, 

i needed more advanced configuration for multiple tracking objects so i extended configuration options. 
Now you can set up `cookieConfig`, `crossDomainLinker`, `crossLinkDomains` per tracking object.
Also multiple tracking object calls are now prefixed with name how they should be: https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#multipletrackers