### PR TITLE
Add support for custom metrics and dimensions in a single hit (analytics.js only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,22 @@ var app = angular.module('app', ['angular-google-analytics'])
         // or create a new pageview event with optional page title
         Analytics.trackPage('/video/detail/XXX', 'Video XXX');
 
+        // or create a new pageview event with optional page title, custom dimension and metric
+        // (analytics.js only)
+        Analytics.trackPage('/video/detail/XXX', 'Video XXX', {dimension15: 'My Custom Dimension', metric18: 8000});
+
         // create a new tracking event
         Analytics.trackEvent('video', 'play', 'django.mp4');
+
+        // create a new tracking event with optional value
+        Analytics.trackEvent('video', 'play', 'django.mp4', 4);
+
+        // create a new tracking event with optional value and noninteraction flag
+        Analytics.trackEvent('video', 'play', 'django.mp4', 4, true);
+
+        // create a new tracking event with optional value, noninteraction flag, and custom dimension and metric
+        // (analytics.js only)
+        Analytics.trackEvent('video', 'play', 'django.mp4', 4, true, {dimension15: 'My Custom Dimension', metric18: 8000});
 
         // tracking e-commerce
         // - create transaction

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -294,9 +294,10 @@ angular.module('angular-google-analytics', [])
        https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
        * @param url
        * @param title
+       * @param custom
        * @private
        */
-      this._trackPage = function (url, title) {
+      this._trackPage = function (url, title, custom) {
         var that = this, args = arguments;
         url = url ? url : getUrl();
         title = title ? title : $document[0].title;
@@ -307,18 +308,19 @@ angular.module('angular-google-analytics', [])
           that._log('_trackPageview', url, title, args);
         });
         _analyticsJs(function () {
+          var opt_fieldObject = {
+            'page': trackPrefix + url,
+            'title': title
+          };
+          if (angular.isObject(custom)) {
+            angular.extend(opt_fieldObject, custom);
+          }
           if (angular.isArray(accountId)) {
             accountId.forEach(function (trackerObj) {
-              $window.ga(_generateCommandName('send', trackerObj), 'pageview', {
-                'page': trackPrefix + url,
-                'title': title
-              });
+              $window.ga(_generateCommandName('send', trackerObj), 'pageview', opt_fieldObject);
             });
           } else {
-            $window.ga('send', 'pageview', {
-              'page': trackPrefix + url,
-              'title': title
-            });
+            $window.ga('send', 'pageview', opt_fieldObject);
           }
           that._log('pageview', url, title, args);
         });
@@ -333,23 +335,31 @@ angular.module('angular-google-analytics', [])
        * @param label
        * @param value
        * @param noninteraction
+       * @param custom
        * @private
        */
-      this._trackEvent = function (category, action, label, value, noninteraction) {
+      this._trackEvent = function (category, action, label, value, noninteraction, custom) {
         var that = this, args = arguments;
         _gaJs(function () {
           $window._gaq.push(['_trackEvent', category, action, label, value, !!noninteraction]);
           that._log('trackEvent', args);
         });
         _analyticsJs(function () {
+          var opt_fieldObject = {};
+          if (angular.isDefined(noninteraction)) {
+            opt_fieldObject['nonInteraction'] = !!noninteraction;
+          }
+          if (angular.isObject(custom)) {
+            angular.extend(opt_fieldObject, custom);
+          }
           if (angular.isArray(accountId)) {
             accountId.forEach(function (trackerObj) {
               if (_checkOption('trackEvent', trackerObj)) {
-                $window.ga(_generateCommandName('send', trackerObj), 'event', category, action, label, value);
+                $window.ga(_generateCommandName('send', trackerObj), 'event', category, action, label, value, opt_fieldObject);
               }
             });
           } else {
-            $window.ga('send', 'event', category, action, label, value);
+            $window.ga('send', 'event', category, action, label, value, opt_fieldObject);
           }
           that._log('event', args);
         });
@@ -752,11 +762,11 @@ angular.module('angular-google-analytics', [])
         enhancedEcommerceEnabled: function () {
           return me._enhancedEcommerceEnabled();
         },
-        trackPage: function (url, title) {
-          me._trackPage(url, title);
+        trackPage: function (url, title, custom) {
+          me._trackPage(url, title, custom);
         },
-        trackEvent: function (category, action, label, value, noninteraction) {
-          me._trackEvent(category, action, label, value, noninteraction);
+        trackEvent: function (category, action, label, value, noninteraction, custom) {
+          me._trackEvent(category, action, label, value, noninteraction, custom);
         },
         addTrans: function (transactionId, affiliation, total, tax, shipping, city, state, country, currency) {
           me._addTrans(transactionId, affiliation, total, tax, shipping, city, state, country, currency);

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -313,19 +313,19 @@ describe('angular-google-analytics', function () {
             Analytics.trackEvent('test');
             expect(Analytics._logs.length).toBe(1);
             expect(Analytics._logs[0][0]).toBe('event');
-            expect($window.ga).toHaveBeenCalledWith('send', 'event', 'test', undefined, undefined, undefined);
+            expect($window.ga).toHaveBeenCalledWith('send', 'event', 'test', undefined, undefined, undefined, {});
           });
         });
       });
 
-      it('should generate eventTracks and ignore non-interactions', function () {
+      it('should generate eventTracks and honour non-interactions', function () {
         inject(function ($window) {
           spyOn($window, 'ga');
           inject(function (Analytics) {
             Analytics.trackEvent('test', 'action', 'label', 0, true);
             expect(Analytics._logs.length).toBe(1);
             expect(Analytics._logs[0][0]).toBe('event');
-            expect($window.ga).toHaveBeenCalledWith('send', 'event', 'test', 'action', 'label', 0);
+            expect($window.ga).toHaveBeenCalledWith('send', 'event', 'test', 'action', 'label', 0, {nonInteraction: true});
           });
         });
       });
@@ -709,9 +709,9 @@ describe('angular-google-analytics', function () {
         spyOn($window, 'ga');
         inject(function (Analytics) {
           Analytics.trackEvent('category', 'action', 'label', 'value');
-          expect($window.ga).toHaveBeenCalledWith('tracker1.send', 'event', 'category', 'action', 'label', 'value');
-          expect($window.ga).not.toHaveBeenCalledWith('tracker2.send', 'event', 'category', 'action', 'label', 'value');
-          expect($window.ga).toHaveBeenCalledWith('send', 'event', 'category', 'action', 'label', 'value');
+          expect($window.ga).toHaveBeenCalledWith('tracker1.send', 'event', 'category', 'action', 'label', 'value', {});
+          expect($window.ga).not.toHaveBeenCalledWith('tracker2.send', 'event', 'category', 'action', 'label', 'value', {});
+          expect($window.ga).toHaveBeenCalledWith('send', 'event', 'category', 'action', 'label', 'value', {});
         });
       });
     });


### PR DESCRIPTION
`Analytics.trackPage()` and `Analytics.trackEvent()` now have an additional optional last parameter `custom`. This parameter holds a dictionary with arbitrary additional fields to be send for this hit.

The `noninteraction` parameter in `Analytics.trackEvent()` is now honoured for analytics.js.