### PR TITLE
Add support for currencies other than USD by default

### DIFF
--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -14,6 +14,7 @@
           ecommerce = false,
           enhancedEcommerce = false,
           enhancedLinkAttribution = false,
+          currency = 'USD',
           removeRegExp,
           experimentId,
           ignoreFirstPageLoad = false,
@@ -85,6 +86,10 @@
         ecommerce = !!val;
         enhancedEcommerce = !!enhanced;
         return true;
+      };
+
+      this.setCurrency = function (currencyCode) {
+        currency = currencyCode;
       };
 
       this.setRemoveRegExp = function (regex) {
@@ -298,6 +303,7 @@
                 $window.ga('require', 'ecommerce', 'ecommerce.js');
               } else {
                 $window.ga('require', 'ec', 'ec.js');
+                $window.ga('set', '&cu', currency);
               }
             }
             if (enhancedLinkAttribution) {

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -469,7 +469,7 @@ describe('angular-google-analytics', function() {
       });
     });
 
-    it('should set Action', function () {
+    it('should set action', function () {
       inject(function (Analytics) {
         expect(Analytics._logs.length).toBe(0);
         var dummyAction = 'dummy';


### PR DESCRIPTION
Got tired of seeing the abandoned PR by TNGPS (https://github.com/TNGPS), so I copied it and incorporated the feedback.

Tests are passing 100% because they weren't modified. I read through the Enhanced E-commerce documentation and it is fine to always set this value, since the default is already USD. The current design makes it impossible to write a test for the verification of this value being added to the ga queue.