### PR TITLE
Centralized GA calls/queueing and made logging consistent

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,6 +131,9 @@ module.exports = function(grunt) {
   // Default task.
   grunt.registerTask('default', ['test']);
 
+  // Static analysis
+  grunt.registerTask('lint', ['jshint']);
+
   // Test tasks.
   grunt.registerTask('test', ['jshint', 'karma:test']);
   grunt.registerTask('test-server', ['karma:server']);

--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ After forking you will need to run the following from a command line to get your
 
 After install you have the following commands available to you from a command line:
 
-1. ```npm test``` or ```grunt``` or ```grunt test```
-2. ```npm test-server``` or ```grunt test-server```
-3. ```grunt build``` or ```grunt release```
-4. ```grunt stage```
+1. ```grunt lint```
+2. ```npm test``` or ```grunt``` or ```grunt test```
+3. ```npm test-server``` or ```grunt test-server```
+4. ```grunt build``` or ```grunt release```
+5. ```grunt stage```

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ AnalyticsProvider.setPageEvent('$stateChangeSuccess');
 AnalyticsProvider.delayScriptTag(true);
 // RegEx to scrub location before sending to analytics. Internally replaces all matching segments with an empty string
 AnalyticsProvider.setRemoveRegExp(/\/\d+?$/);
+// Log all outbound calls to Google Analytics to an in-memory array accessible via ```Analytics._logs```. Logging is disabled (false) by default
+AnalyticsProvider.logAllCalls(true);
 ```
 
 ## AdBlock EasyPrivacy


### PR DESCRIPTION
* Added logAllCalls configuration to do an in-memory store of all calls made to GA for debugging purposes.
* Created method _gaq to wrap calls to $window._gaq.push in order to facilitate logging and ensure existence in a single location.
* Created method _ga to wrap calls to $window.ga in order to facilitate logging and warn if ga method doesn't exist.
* Cleaned up the usage of me, that, and this. 'me' has been replaced with 'that'.
* Removed numerous 'var that = this, args = arguments;' statements that no longer serve any purpose.
* Updated all tests to handle the standardized way logging is now performed. Tests are 100% passing with improved verifications added to some methods.
* Simplified numerous tests to use toEqual for arrays instead of multiple toBe statements.