### PR TITLE
Encapsulated multiple tracker handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ var app = angular.module('app', ['angular-google-analytics'])
            { tracker: 'UA-12345-34', name: "tracker2" }
         ]);
 
+        // Or if needing to override properties for specific tracking objects (analytics.js only)
+        AnalyticsProvider.setAccount([
+            {
+                tracker: 'UA-12345-12',
+                name: "tracker1",
+                cookieConfig: {
+                    cookieDomain: 'foo.example.com',
+                    cookieName: 'myNewName',
+                    cookieExpires: 20000
+                },
+                crossDomainLinker: true,
+                crossLinkDomains: ['domain-1.com', 'domain-2.com'],
+                trackEvent: true
+            }
+        ]);        
+
         // Track all routes (or not)
         AnalyticsProvider.trackPages(true);
 
@@ -82,9 +98,9 @@ var app = angular.module('app', ['angular-google-analytics'])
 
         // Set custom cookie parameters for analytics.js
         AnalyticsProvider.setCookieConfig({
-          cookieDomain: 'foo.example.com',
-          cookieName: 'myNewName',
-          cookieExpires: 20000
+            cookieDomain: 'foo.example.com',
+            cookieName: 'myNewName',
+            cookieExpires: 20000
         });
 
         // Change page event name

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -4,7 +4,7 @@
     .provider('Analytics', function () {
       var created = false,
           trackRoutes = true,
-          accountId,
+          accounts,
           displayFeatures,
           trackPrefix = '',
           domainName,
@@ -20,16 +20,28 @@
           ignoreFirstPageLoad = false,
           crossDomainLinker = false,
           crossLinkDomains,
-          linkerConfig = {'allowLinker': true},
           trackUrlParams = false,
           delayScriptTag = false,
           logAllCalls = false;
 
       this._logs = [];
 
-      // config methods
-      this.setAccount = function (id) {
-        accountId = id;
+      /**
+       * Configuration Methods
+       **/
+
+      this.setAccount = function (tracker) {
+        if (angular.isUndefined(tracker) || tracker === false) {
+          accounts = undefined;
+        } else if (angular.isArray(tracker)) {
+          accounts = tracker;
+        } else if (angular.isObject(tracker)) {
+          accounts = [tracker];
+        } else {
+          // In order to preserve an existing behavior with how the _trackEvent function works,
+          // the trackEvent property must be set to true when there is only a single tracker.
+          accounts = [{ tracker: tracker, trackEvent: true }];
+        }
         return true;
       };
 
@@ -133,6 +145,18 @@
       this.$get = ['$document', '$location', '$log', '$rootScope', '$window', function ($document, $location, $log, $rootScope, $window) {
         var that = this;
 
+        /**
+         * Side-effect Free Helper Methods
+         **/
+
+        var generateCommandName = function (commandName, config) {
+          return isPropertyDefined('name', config) ? (config.name + '.' + commandName) : commandName;
+        };
+
+        var isPropertyDefined = function (key, config) {
+          return angular.isObject(config) && angular.isDefined(config[key]);
+        };
+
         var getUrl = function () {
           var url = trackUrlParams ? $location.url() : $location.path();
           return removeRegExp ? url.replace(removeRegExp, '') : url;
@@ -154,7 +178,6 @@
             if (angular.isDefined(campaignVar)) {
               object[campaignVar] = value;
             }
-
           });
 
           return object;
@@ -164,13 +187,13 @@
          * Private Methods
          */
 
-        var _gaJs = function(fn) {
+        var _gaJs = function (fn) {
           if (!analyticsJS && $window._gaq && typeof fn === 'function') {
             fn();
           }
         };
 
-        var _gaq = function() {
+        var _gaq = function () {
           if (!$window._gaq) {
             $window._gaq = [];
           }
@@ -180,15 +203,16 @@
           $window._gaq.push.apply($window._gaq, arguments);
         };
 
-        var _analyticsJs = function(fn) {
+        var _analyticsJs = function (fn) {
           if (analyticsJS && $window.ga && typeof fn === 'function') {
             fn();
           }
         };
 
-        var _ga = function() {
-          if (!$window.ga) {
+        var _ga = function () {
+          if (typeof $window.ga !== 'function') {
             that._log('warn', 'ga function not set on window');
+            return;
           }
           if (logAllCalls === true) {
             that._log.apply(that, arguments);
@@ -196,15 +220,26 @@
           $window.ga.apply(null, arguments);
         };
 
-        var _generateCommandName = function(commandName, config) {
-          if (!angular.isUndefined(config) && 'name' in config && config.name) {
-            return config.name + '.' + commandName;
+        var _gaMultipleTrackers = function (includeFn) {
+          if (typeof $window.ga !== 'function') {
+            that._log('warn', 'ga function not set on window');
+            return;
           }
-          return commandName;
-        };
 
-        var _checkOption = function(key, config) {
-          return key in config && config[key];
+          // Drop the includeFn from the arguments and preserve the original command name
+          var args = Array.prototype.slice.call(arguments, 1),
+              commandName = args[0];
+
+          accounts.forEach(function (trackerObj) {
+            if (typeof includeFn === 'function' && !includeFn(trackerObj)) {
+              return;
+            }
+            args[0] = generateCommandName(commandName, trackerObj);
+            if (logAllCalls === true) {
+              that._log.apply(that, args);
+            }
+            $window.ga.apply(null, args);                
+          });
         };
 
         this._log = function () {
@@ -224,18 +259,22 @@
         };
 
         this._createScriptTag = function () {
-          if (!accountId) {
+          if (!accounts || accounts.length < 1) {
             this._log('warn', 'No account id set to create script tag');
             return;
           }
+          if (accounts.length > 1) {
+            this._log('warn', 'Multiple trackers are not supported with ga.js. Using first tracker only');
+            accounts = accounts.slice(0, 1);
+          }
 
-          if (created) {
-            this._log('warn', 'Script tag already created');
+          if (created === true) {
+            this._log('warn', 'ga.js or analytics.js script tag already created');
             return;
           }
 
-          // inject the google analytics tag
-          _gaq(['_setAccount', accountId]);
+          // inject the Google Analytics tag
+          _gaq(['_setAccount', accounts[0].tracker]);
           if(domainName) {
             _gaq(['_setDomainName', domainName]);
           }
@@ -267,58 +306,43 @@
         };
 
         this._createAnalyticsScriptTag = function () {
-          if (!accountId) {
+          if (!accounts) {
             this._log('warn', 'No account id set to create analytics script tag');
             return;
           }
 
-          if (created) {
-            this._log('warn', 'Analytics script tag already created');
+          if (created === true) {
+            this._log('warn', 'ga.js or analytics.js script tag already created');
             return;
           }
 
-          // inject the google analytics tag
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          // inject the Google Analytics tag
+          (function (i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function (){
             (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
             m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-          if (angular.isArray(accountId)) {
-            accountId.forEach(function (trackerObj) {
-              var _cookieConfig = 'cookieConfig' in trackerObj ? trackerObj.cookieConfig : cookieConfig;
-              var options;
-              if (_checkOption('crossDomainLinker', trackerObj)) {
-                trackerObj.allowLinker = trackerObj.crossDomainLinker;
-              }
-              angular.forEach(['name', 'allowLinker'], function(key) {
-                if (key in trackerObj) {
-                  if (angular.isUndefined(options)) {
-                    options = {};
-                  }
-                  options[key] = trackerObj[key];
-                }
-              });
-              if (angular.isUndefined(options)) {
-                _ga('create', trackerObj.tracker, _cookieConfig);
-              } else {
-                _ga('create', trackerObj.tracker, _cookieConfig, options);
-              }
-              if (options && 'allowLinker' in options && options.allowLinker) {
-                _ga(_generateCommandName('require', trackerObj), 'linker');
-                if (_checkOption('crossLinkDomains', trackerObj)) {
-                  _ga(_generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
-                }
-              }
-            });
-          } else if (crossDomainLinker) {
-            _ga('create', accountId, cookieConfig, linkerConfig);
-            _ga('require', 'linker');
-            if(crossLinkDomains) {
-              _ga('linker:autoLink', crossLinkDomains );
+          accounts.forEach(function (trackerObj) {
+            var options = {};
+            trackerObj.crossDomainLinker = isPropertyDefined('crossDomainLinker', trackerObj) ? trackerObj.crossDomainLinker : crossDomainLinker;
+            trackerObj.cookieConfig = isPropertyDefined('cookieConfig', trackerObj) ? trackerObj.cookieConfig : cookieConfig;
+            trackerObj.crossLinkDomains = isPropertyDefined('crossLinkDomains', trackerObj) ? trackerObj.crossLinkDomains : crossLinkDomains;
+            trackerObj.trackEvent = isPropertyDefined('trackEvent', trackerObj) ? trackerObj.trackEvent : false;
+
+            options.allowLinker = trackerObj.crossDomainLinker;
+            if (isPropertyDefined('name', trackerObj)) {
+              options.name = trackerObj.name;
             }
-          } else {
-            _ga('create', accountId, cookieConfig);
-          }
+
+            _ga('create', trackerObj.tracker, trackerObj.cookieConfig, options);
+
+            if (trackerObj.crossDomainLinker === true) {
+              _ga(generateCommandName('require', trackerObj), 'linker');
+              if (angular.isDefined(trackerObj.crossLinkDomains)) {
+                _ga(generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
+              }
+            }
+          });
 
           if (displayFeatures) {
             _ga('require', 'displayfeatures');
@@ -336,9 +360,11 @@
               _ga('set', '&cu', currency);
             }
           }
+
           if (enhancedLinkAttribution) {
             _ga('require', 'linkid', 'linkid.js');
           }
+
           if (experimentId) {
             var expScript = document.createElement('script'),
               s = document.getElementsByTagName('script')[0];
@@ -384,13 +410,7 @@
             if (angular.isObject(custom)) {
               angular.extend(opt_fieldObject, custom);
             }
-            if (angular.isArray(accountId)) {
-              accountId.forEach(function (trackerObj) {
-                _ga(_generateCommandName('send', trackerObj), 'pageview', opt_fieldObject);
-              });
-            } else {
-              _ga('send', 'pageview', opt_fieldObject);
-            }
+            _gaMultipleTrackers(undefined, 'send', 'pageview', opt_fieldObject);
           });
         };
 
@@ -412,21 +432,17 @@
           });
           _analyticsJs(function () {
             var opt_fieldObject = {};
+            var includeFn = function (trackerObj) {
+              return isPropertyDefined('trackEvent', trackerObj) && trackerObj.trackEvent === true;
+            };
+
             if (angular.isDefined(noninteraction)) {
               opt_fieldObject.nonInteraction = !!noninteraction;
             }
             if (angular.isObject(custom)) {
               angular.extend(opt_fieldObject, custom);
             }
-            if (angular.isArray(accountId)) {
-              accountId.forEach(function (trackerObj) {
-                if (_checkOption('trackEvent', trackerObj)) {
-                  _ga(_generateCommandName('send', trackerObj), 'event', category, action, label, value, opt_fieldObject);
-                }
-              });
-            } else {
-              _ga('send', 'event', category, action, label, value, opt_fieldObject);
-            }
+            _gaMultipleTrackers(includeFn, 'send', 'event', category, action, label, value, opt_fieldObject);
           });
         };
 
@@ -767,7 +783,7 @@
           });
         };
 
-        this._pageView = function() {
+        this._pageView = function () {
           this._send('pageview');
         };
 
@@ -796,7 +812,7 @@
           this._send('timing', timingCategory, timingVar, timingValue, timingLabel);
         };
 
-        // creates the Google analytics tracker
+        // creates the Google Analytics tracker
         if (!delayScriptTag) {
           if (analyticsJS) {
             this._createAnalyticsScriptTag();

--- a/test/unit/angular-google-analytics.js
+++ b/test/unit/angular-google-analytics.js
@@ -11,7 +11,7 @@ describe('angular-google-analytics', function() {
   describe('required settings missing', function () {
     describe('for default ga script injection', function () {
       beforeEach(module(function (AnalyticsProvider) {
-        AnalyticsProvider.setAccount(false);
+        AnalyticsProvider.setAccount(undefined);
         AnalyticsProvider.useAnalytics(false);
       }));
 
@@ -36,7 +36,7 @@ describe('angular-google-analytics', function() {
 
     describe('for analytics script injection', function () {
       beforeEach(module(function (AnalyticsProvider) {
-        AnalyticsProvider.setAccount(false);
+        AnalyticsProvider.setAccount(undefined);
         AnalyticsProvider.useAnalytics(true);
       }));
 
@@ -614,9 +614,9 @@ describe('angular-google-analytics', function() {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
-          expect($window.ga).toHaveBeenCalledWith('create', trackers[0].tracker, 'auto', { name: trackers[0].name });
-          expect($window.ga).toHaveBeenCalledWith('create', trackers[1].tracker, 'auto', { name: trackers[1].name });
-          expect($window.ga).toHaveBeenCalledWith('create', trackers[2].tracker, 'auto');
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[0].tracker, 'auto', { allowLinker: false, name: trackers[0].name });
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[1].tracker, 'auto', { allowLinker: false, name: trackers[1].name });
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[2].tracker, 'auto', { allowLinker: false });
         });
       });
     });
@@ -675,7 +675,7 @@ describe('angular-google-analytics', function() {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
-          expect($window.ga).toHaveBeenCalledWith('create', 'UA-12345-67', 'yourdomain.org');
+          expect($window.ga).toHaveBeenCalledWith('create', 'UA-12345-67', 'yourdomain.org', { allowLinker: false });
         });
       });
     });


### PR DESCRIPTION
* The previous design for supporting single or multiple trackers forced copy-paste coding and special cased the scenario of a single tracker versus multiple trackers. This change makes account handling generic and encapsulates the logic for how multiple trackers are called to a single location with backwards compatibility preserved. GA commands that support multiple trackers will be trivial to add support for now, but will require additional tests in order to onboard properly.

* Standardized the generation of the create script tag for Analytics.js to make generation consistent without special casing on whether there were one or many trackers defined.

* The setAccount configuration method now supports a more complete set of formats. Those are: 1) no argument / undefined / false will unset the accounts previously defined, 2) an array of tracker objects, 3) a single tracker object, and 4) a single tracker identifier. This preserves backwards compatibility.