### PR TITLE
Test organization and multiple tracker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ var app = angular.module('app', ['angular-google-analytics'])
                 },
                 crossDomainLinker: true,
                 crossLinkDomains: ['domain-1.com', 'domain-2.com'],
-                trackEvent: true
+                trackEvent: true,
+                trackEcommerce: true
             }
         ]);
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ var app = angular.module('app', ['angular-google-analytics'])
         Analytics.addPromo(productId, name, creative, position);
         Analytics.addPromo(productId, name, creative, position);
         Analytics.pageView();
-        // Note: Before tracking promotion Click, call pageView otherwise promotion impressions will be treated as promotion clicks
+        // Note: Before tracking promotion click, call pageView, otherwise promotion impressions will be treated as promotion clicks
         // example:
         Analytics.addPromo('PROMO_1234', 'Summer Sale', 'summer_banner2', 'banner_slot1');
         Analytics.pageView();
@@ -224,17 +224,19 @@ var app = angular.module('app', ['angular-google-analytics'])
         Analytics.addPromo('PROMO_1234', 'Summer Sale', 'summer_banner2', 'banner_slot1');
         Analytics.promoClick('Summer Sale');
 
-        // populate a custom dimension
+        // Populate a custom dimension
         Analytics.set('dimension1', 'Paid');
+        // or set the User Id
+        Analytics.set('&uid', 1234);
 
         // Manually create script tag after using delayScriptTag
-        Analytics.createScriptTag({userId: 1234});
+        Analytics.createScriptTag({ userId: 1234 });
 
         // Manually create Analytics script tag after using delayScriptTag
-        Analytics.createAnalyticsScriptTag({userId: 1234})
+        Analytics.createAnalyticsScriptTag({ userId: 1234 });
 
         // Track User Timings
-        Analytics.trackTimings(timingCategory, timingVar, timingValue, timingLabel)
+        Analytics.trackTimings(timingCategory, timingVar, timingValue, timingLabel);
         // example:
         var endTime = new Date().getTime();
         var timeSpent = endTime - startTime;

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -376,12 +376,24 @@
           return true;
         };
 
-        this._ecommerceEnabled = function () {
-          return ecommerce && !enhancedEcommerce;
+        this._ecommerceEnabled = function (warn, command) {
+          var result = ecommerce && !enhancedEcommerce;
+          if (warn === true && result === false) {
+            if (ecommerce && enhancedEcommerce) {
+              that._log('warn', command + ' is not available when Enhanced Ecommerce is enabled with analytics.js');
+            } else {
+              that._log('warn', 'Ecommerce must be enabled to use ' + command + ' with analytics.js');
+            }
+          }
+          return result;
         };
 
-        this._enhancedEcommerceEnabled = function () {
-          return ecommerce && enhancedEcommerce;
+        this._enhancedEcommerceEnabled = function (warn, command) {
+          var result = ecommerce && enhancedEcommerce;
+          if (warn === true && result === false) {
+            that._log('warn', 'Enhanced Ecommerce must be enabled to use ' + command + ' with analytics.js');
+          }
+          return result;
         };
 
         /**
@@ -465,7 +477,7 @@
             _gaq(['_addTrans', transactionId, affiliation, total, tax, shipping, city, state, country]);
           });
           _analyticsJs(function () {
-            if (that._ecommerceEnabled()) {
+            if (that._ecommerceEnabled(true, 'addTrans')) {
               _ga('ecommerce:addTransaction', {
                 id: transactionId,
                 affiliation: affiliation,
@@ -474,8 +486,6 @@
                 shipping: shipping,
                 currency: currency || 'USD'
               });
-            } else {
-              that._log('warn', 'Ecommerce must be enabled to use addTrans with analytics.js');
             }
           });
         };
@@ -497,7 +507,7 @@
             _gaq(['_addItem', transactionId, sku, name, category, price, quantity]);
           });
           _analyticsJs(function () {
-            if (that._ecommerceEnabled()) {
+            if (that._ecommerceEnabled(true, 'addItem')) {
               _ga('ecommerce:addItem', {
                 id: transactionId,
                 name: name,
@@ -506,8 +516,6 @@
                 price: price,
                 quantity: quantity
               });
-            } else {
-              that._log('warn', 'Ecommerce must be enabled to use addItem with analytics.js');
             }
           });
         };
@@ -523,10 +531,8 @@
             _gaq(['_trackTrans']);
           });
           _analyticsJs(function () {
-            if (that._ecommerceEnabled()) {
+            if (that._ecommerceEnabled(true, 'trackTrans')) {
               _ga('ecommerce:send');
-            } else {
-              that._log('warn', 'Ecommerce must be enabled to use trackTrans with analytics.js');
             }
           });
         };
@@ -538,10 +544,8 @@
          */
         this._clearTrans = function () {
           _analyticsJs(function () {
-            if (that._ecommerceEnabled()) {
+            if (that._ecommerceEnabled(true, 'clearTrans')) {
               _ga('ecommerce:clear');
-            } else {
-              that._log('warn', 'Ecommerce must be enabled to use clearTrans with analytics.js');
             }
           });
         };
@@ -568,7 +572,7 @@
             _gaq(['_addProduct', productId, name, category, brand, variant, price, quantity, coupon, position]);
           });
           _analyticsJs(function () {
-            if (that._enhancedEcommerceEnabled()) {
+            if (that._enhancedEcommerceEnabled(true, 'addProduct')) {
               _ga('ec:addProduct', {
                 id: productId,
                 name: name,
@@ -580,8 +584,6 @@
                 coupon: coupon,
                 position: position
               });
-            } else {
-              that._log('warn', 'Enhanced ecommerce must be enabled to use addProduct with analytics.js');
             }
           });
         };
@@ -603,7 +605,7 @@
             _gaq(['_addImpression', id, name, list, brand, category, variant, position, price]);
           });
           _analyticsJs(function () {
-            if (that._enhancedEcommerceEnabled()) {
+            if (that._enhancedEcommerceEnabled(true, 'addImpression')) {
               _ga('ec:addImpression', {
                 id: id,
                 name: name,
@@ -614,8 +616,6 @@
                 position: position,
                 price: price
               });
-            } else {
-              that._log('warn', 'Enhanced ecommerce must be enabled to use addImpression with analytics.js');
             }
           });
         };
@@ -633,15 +633,13 @@
             _gaq(['_addPromo', productId, name, creative, position]);
           });
           _analyticsJs(function () {
-            if (that._enhancedEcommerceEnabled()) {
+            if (that._enhancedEcommerceEnabled(true, 'addPromo')) {
               _ga('ec:addPromo', {
                 id: productId,
                 name: name,
                 creative: creative,
                 position: position
               });
-            } else {
-              that._log('warn', 'Enhanced ecommerce must be enabled to use addPromo with analytics.js');
             }
           });
         };
@@ -686,10 +684,8 @@
             _gaq(['_setAction', action, obj]);
           });
           _analyticsJs(function () {
-            if (that._enhancedEcommerceEnabled()) {
+            if (that._enhancedEcommerceEnabled(true, 'setAction')) {
               _ga('ec:setAction', action, obj);
-            } else {
-              that._log('warn', 'Enhanced ecommerce must be enabled to use setAction with analytics.js');
             }
           });
         };

--- a/test/unit/classic-google-analytics.js
+++ b/test/unit/classic-google-analytics.js
@@ -1,0 +1,311 @@
+/* global before, beforeEach, describe, document, expect, inject, it, module, spyOn */
+'use strict';
+
+describe('angular-google-analytics classic (ga.js)', function() {
+  beforeEach(module('angular-google-analytics'));
+  beforeEach(module(function (AnalyticsProvider) {
+    AnalyticsProvider.setAccount('UA-XXXXXX-xx');
+    AnalyticsProvider.useAnalytics(false);
+    AnalyticsProvider.logAllCalls(true);
+  }));
+
+  describe('required settings missing', function () {
+    describe('for default ga script injection', function () {
+      beforeEach(module(function (AnalyticsProvider) {
+        AnalyticsProvider.setAccount(undefined);
+      }));
+
+      it('should not inject a script tag', function () {
+        inject(function (Analytics) {
+          expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(0);
+        });
+      });
+
+      it('should issue a warning to the log', function () {
+        inject(function ($log) {
+          spyOn($log, 'warn');
+          inject(function (Analytics) {
+            expect(Analytics._logs.length).toBe(1);
+            expect(Analytics._logs[0][0]).toBe('warn');
+            expect(Analytics._logs[0][1]).toBe('No account id set to create script tag');
+            expect($log.warn).toHaveBeenCalledWith(['No account id set to create script tag']);
+          });
+        });
+      });
+    });
+  });
+
+  describe('enabled delayed script tag', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.delayScriptTag(true);
+    }));
+
+    it('should have a truthy value for Analytics.delayScriptTag', function () {
+      inject(function (Analytics, $location) {
+        expect(Analytics.delayScriptTag).toBe(true);
+      });
+    });
+
+    it('should not inject a script tag', function () {
+      inject(function (Analytics) {
+        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(0);
+      });
+    });
+  });
+
+  describe('does not support multiple tracking objects', function () {
+    var trackers = [
+      { tracker: 'UA-12345-12', name: "tracker1" },
+      { tracker: 'UA-12345-45' }
+    ];
+
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.setAccount(trackers);
+    }));
+
+    it('should issue a warning to the log', function () {
+      inject(function ($log) {
+        spyOn($log, 'warn');
+        inject(function (Analytics) {
+          expect(Analytics._logs.length).toBe(3);
+          expect(Analytics._logs[0][0]).toBe('warn');
+          expect(Analytics._logs[0][1]).toBe('Multiple trackers are not supported with ga.js. Using first tracker only');
+          expect($log.warn).toHaveBeenCalledWith(['Multiple trackers are not supported with ga.js. Using first tracker only']);
+        });
+      });
+    });
+  });
+  
+  describe('create script tag', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.delayScriptTag(true);
+    }));
+
+    it('should inject a script tag', function () {
+      inject(function (Analytics) {
+        var scriptCount = document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length;
+        Analytics.createScriptTag({ userId: 1234 });
+        expect(Analytics.getCookieConfig().userId).toBe(1234);
+        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount + 1);
+      });
+    });
+
+    it('should warn and prevent a second attempt to inject a script tag', function () {
+      inject(function ($log) {
+        spyOn($log, 'warn');
+        inject(function (Analytics) {
+          var scriptCount = document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length;
+          Analytics.createScriptTag({ userId: 1234 });
+          expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount + 1);
+          Analytics.createScriptTag({ userId: 1234 });
+          expect($log.warn).toHaveBeenCalledWith(['ga.js or analytics.js script tag already created']);
+          expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount + 1);
+        });
+      });
+    });
+  });
+
+  describe('automatic trackPages with ga.js', function () {
+    it('should inject the GA script', function () {
+      var scriptCount = document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length;
+      inject(function (Analytics) {
+        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount + 1);
+      });
+    });
+
+    it('should generate trackPages', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.trackPage('test');
+        expect(length + 2).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_set', 'title', '']);
+        expect($window._gaq[length + 1]).toEqual(['_trackPageview', 'test']);
+      });
+    });
+
+    it('should generate a trackPage on routeChangeSuccess', function () {
+      inject(function (Analytics, $rootScope, $window) {
+        var length = $window._gaq.length;
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect(length + 2).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_set', 'title', '']);
+        expect($window._gaq[length + 1]).toEqual(['_trackPageview', '']);
+      });
+    });
+  });
+
+  describe('NOT automatic trackPages', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.trackPages(false);
+    }));
+
+    it('should NOT generate a trackpage on routeChangeSuccess', function () {
+      inject(function (Analytics, $rootScope, $window) {
+        var length = $window._gaq.length;
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect(length).toBe($window._gaq.length);
+      });
+    });
+
+    it('should generate a trackpage when explicitly called', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.trackPage('/page/here');
+        expect(length + 2).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_set', 'title', '']);
+        expect($window._gaq[length + 1]).toEqual(['_trackPageview', '/page/here']);
+      });
+    });
+  });
+
+  describe('eventTracks with ga.js', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.trackPages(false);
+    }));
+
+    it('should generate eventTracks', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.trackEvent('test');
+        expect(length + 1).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_trackEvent', 'test', undefined, undefined, undefined, false]);
+      });
+    });
+
+    it('should generate eventTracks with non-interactions', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.trackEvent('test', 'action', 'label', 0, true);
+        expect(length + 1).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_trackEvent', 'test', 'action', 'label', 0, true]);
+      });
+    });
+  });
+
+  describe('supports dc.js', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.useDisplayFeatures(true);
+    }));
+
+    it('should inject the DC script', function () {
+      inject(function (Analytics) {
+        expect(document.querySelectorAll("script[src='http://stats.g.doubleclick.net/dc.js']").length).toBe(1);
+      });
+    });
+  });
+
+  describe('e-commerce transactions', function () {
+    it('should add transcation', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.addTrans('1', '', '2.42', '0.42', '0', 'Amsterdam', '', 'Netherlands');
+        expect(length + 1).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_addTrans', '1', '', '2.42', '0.42', '0', 'Amsterdam', '', 'Netherlands']);
+      });
+    });
+
+    it('should add an item to transaction', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.addItem('1', 'sku-1', 'Test product 1', 'Testing', '1', '1');
+        expect(length + 1).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_addItem', '1', 'sku-1', 'Test product 1', 'Testing', '1', '1']);
+        Analytics.addItem('1', 'sku-2', 'Test product 2', 'Testing', '1', '1');
+        expect(length + 2).toBe($window._gaq.length);
+        expect($window._gaq[length + 1]).toEqual(['_addItem', '1', 'sku-2', 'Test product 2', 'Testing', '1', '1']);
+      });
+    });
+
+    it('should track the transaction', function () {
+      inject(function (Analytics, $window) {
+        var length = $window._gaq.length;
+        Analytics.trackTrans();
+        expect(length + 1).toBe($window._gaq.length);
+        expect($window._gaq[length]).toEqual(['_trackTrans']);
+      });
+    });
+  });
+
+  describe('supports ignoreFirstPageLoad', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.ignoreFirstPageLoad(true);
+    }));
+
+    it('supports ignoreFirstPageLoad config', function () {
+      inject(function (Analytics, $rootScope) {
+        expect(Analytics.ignoreFirstPageLoad).toBe(true);
+      });
+    });
+  });
+
+  describe('supports arbitrary page events', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.setPageEvent('$stateChangeSuccess');
+    }));
+
+    it('should inject the Analytics script', function () {
+      inject(function (Analytics, $rootScope) {
+        var length = Analytics._logs.length;
+        $rootScope.$broadcast('$stateChangeSuccess');
+        expect(length + 2).toBe(Analytics._logs.length);
+        expect(Analytics._logs[length][0]).toEqual(['_set', 'title', '']);
+        expect(Analytics._logs[length + 1][0]).toEqual(['_trackPageview', '']);
+      });
+    });
+  });
+
+  describe('supports RegExp path scrubbing', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.setRemoveRegExp(new RegExp(/\/\d+?$/));
+    }));
+
+    it('should scrub urls', function () {
+      inject(function (Analytics, $location) {
+        $location.path('/some-crazy/page/with/numbers/123456');
+        expect(Analytics.getUrl()).toBe('/some-crazy/page/with/numbers');
+      });
+    });
+  });
+
+  describe('parameter defaulting on trackPage', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.trackPages(false);
+    }));
+
+    it('should set url and title when no parameters provided', function () {
+      inject(function (Analytics, $document, $location) {
+        $location.path('/page/here');
+        $document[0] = { title: 'title here' };
+        var length = Analytics._logs.length;
+        Analytics.trackPage();
+        expect(length + 2).toBe(Analytics._logs.length);
+        expect(Analytics._logs[length][0]).toEqual(['_set', 'title', 'title here']);
+        expect(Analytics._logs[length + 1][0]).toEqual(['_trackPageview', '/page/here']);
+      });
+    });
+
+    it('should set title when no title provided', function () {
+      inject(function (Analytics, $document) {
+        $document[0] = { title: 'title here' };
+        var length = Analytics._logs.length;
+        Analytics.trackPage('/page/here');
+        expect(length + 2).toBe(Analytics._logs.length);
+        expect(Analytics._logs[length][0]).toEqual(['_set', 'title', 'title here']);
+        expect(Analytics._logs[length + 1][0]).toEqual(['_trackPageview', '/page/here']);
+      });
+    });
+  });
+
+  describe('enabled url params tracking', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.trackUrlParams(true);
+    }));
+
+    it('should grab query params in the url', function () {
+      inject(function (Analytics, $location) {
+        $location.url('/some/page?with_params=foo&more_param=123');
+        expect(Analytics.getUrl()).toContain('?with_params=foo&more_param=123');
+      });
+    });
+  });
+});

--- a/test/unit/directives.js
+++ b/test/unit/directives.js
@@ -1,0 +1,73 @@
+/* global before, beforeEach, describe, document, expect, inject, it, module, spyOn */
+'use strict';
+describe('angular-google-analytics directives', function() {
+  beforeEach(module('angular-google-analytics'));
+  beforeEach(module(function (AnalyticsProvider) {
+    AnalyticsProvider.setAccount('UA-XXXXXX-xx');
+    AnalyticsProvider.logAllCalls(true);
+  }));
+
+  describe('directives', function () {
+    describe('gaTrackEvent', function () {
+      it('should evaluate scope params', function () {
+        inject(function (Analytics, $rootScope, $compile) {
+          spyOn(Analytics, 'trackEvent');
+          var scope = $rootScope.$new(),
+              element = '<div ga-track-event="[event, action, label]">test</div>',
+              compiled = $compile(element)(scope);
+
+          scope.event = 'button';
+          scope.action = 'click';
+          scope.label = 'Some Button';
+
+          scope.$digest();
+          compiled.triggerHandler('click');
+          expect(Analytics.trackEvent).toHaveBeenCalledWith('button', 'click', 'Some Button');
+        });
+      });
+
+      it('should track an event when clicked', function () {
+        inject(function (Analytics, $rootScope, $compile) {
+          spyOn(Analytics, 'trackEvent');
+          var scope = $rootScope.$new(),
+              element = '<div ga-track-event="[\'button\', \'click\', \'Some Button\']">test</div>',
+              compiled = $compile(element)(scope);
+          scope.$digest();
+          compiled.triggerHandler('click');
+          expect(Analytics.trackEvent).toHaveBeenCalledWith('button', 'click', 'Some Button');
+        });
+      });
+
+      it('should inherit parent scope', function () {
+        inject(function (Analytics, $rootScope, $compile) {
+          spyOn(Analytics, 'trackEvent');
+          var scope = $rootScope.$new(), element, compiled;
+          scope.event = ['button', 'click', 'Some Button'];
+          element = '<div ga-track-event="event">test</div>';
+          compiled = $compile(element)(scope);
+          scope.$digest();
+          compiled.triggerHandler('click');
+          expect(Analytics.trackEvent).toHaveBeenCalledWith('button', 'click', 'Some Button');
+        });
+      });
+
+      it('should abort if gaTrackEventIf is false', function () {
+        inject(function (Analytics, $rootScope, $compile) {
+          spyOn(Analytics, 'trackEvent');
+          var scope = $rootScope.$new(),
+              element = '<div ga-track-event="[\'button\', \'click\', \'Some Button\']" ga-track-event-if="false">test</div>',
+              compiled = $compile(element)(scope);
+          scope.$digest();
+          compiled.triggerHandler('click');
+          expect(Analytics.trackEvent.calls.length).toBe(0);
+
+          element = '<div ga-track-event="[\'button\', \'click\', \'Some Button\']" ga-track-event-if="true">test</div>';
+          compiled = $compile(element)(scope);
+          scope.$digest();
+          compiled.triggerHandler('click');
+          expect(Analytics.trackEvent.calls.length).toBe(1);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -290,6 +290,31 @@ describe('angular-google-analytics universal (analytics.js)', function() {
         });
       });
     });
+
+    describe('supports multiple tracking objects', function () {
+      var trackers = [
+        { tracker: 'UA-12345-12', name: "tracker1", trackEcommerce: true },
+        { tracker: 'UA-12345-34', name: "tracker2" },
+        { tracker: 'UA-12345-45', trackEcommerce: true }
+      ];
+
+      beforeEach(module(function (AnalyticsProvider) {
+        AnalyticsProvider.setAccount(trackers);
+      }));
+
+      it('should track transactions for configured tracking objects only', function () {
+        inject(function ($window) {
+          spyOn($window, 'ga');
+          inject(function (Analytics) {
+            var length = Analytics._logs.length;
+            Analytics.trackTrans();
+            expect(length + 2).toBe(Analytics._logs.length);
+            expect($window.ga).toHaveBeenCalledWith('tracker1.ecommerce:send');
+            expect($window.ga).toHaveBeenCalledWith('ecommerce:send');
+          });
+        });
+      });
+    });
   });
 
   describe('enhanced e-commerce transactions with analytics.js', function () {
@@ -325,17 +350,19 @@ describe('angular-google-analytics universal (analytics.js)', function() {
           var length = Analytics._logs.length;
           Analytics.addProduct('sku-2', 'Test Product 2', 'Category-1', 'Brand 2', 'variant-3', '2499', '1', 'FLAT10', '1');
           expect(length + 1).toBe(Analytics._logs.length);
-          expect($window.ga).toHaveBeenCalledWith('ec:addProduct', {
-            id: 'sku-2',
-            name: 'Test Product 2',
-            category: 'Category-1',
-            brand: 'Brand 2',
-            variant: 'variant-3',
-            price: '2499',
-            quantity: '1',
-            coupon: 'FLAT10',
-            position: '1'
-          });
+          expect($window.ga).toHaveBeenCalledWith(
+            'ec:addProduct',
+            {
+              id: 'sku-2',
+              name: 'Test Product 2',
+              category: 'Category-1',
+              brand: 'Brand 2',
+              variant: 'variant-3',
+              price: '2499',
+              quantity: '1',
+              coupon: 'FLAT10',
+              position: '1'
+            });
         });
       });
     });
@@ -470,6 +497,55 @@ describe('angular-google-analytics universal (analytics.js)', function() {
         });
       });
     });
+
+    describe('supports multiple tracking objects', function () {
+      var trackers = [
+        { tracker: 'UA-12345-12', name: "tracker1" },
+        { tracker: 'UA-12345-34', name: "tracker2", trackEcommerce: true },
+        { tracker: 'UA-12345-45', trackEcommerce: true }
+      ];
+
+      beforeEach(module(function (AnalyticsProvider) {
+        AnalyticsProvider.setAccount(trackers);
+      }));
+
+      it('should add product for configured tracking objects only', function () {
+        inject(function ($window) {
+          spyOn($window, 'ga');
+          inject(function (Analytics) {
+            var length = Analytics._logs.length;
+            Analytics.addProduct('sku-2', 'Test Product 2', 'Category-1', 'Brand 2', 'variant-3', '2499', '1', 'FLAT10', '1');
+            expect(length + 2).toBe(Analytics._logs.length);
+            expect($window.ga).toHaveBeenCalledWith(
+              'ec:addProduct',
+              {
+                id: 'sku-2',
+                name: 'Test Product 2',
+                category: 'Category-1',
+                brand: 'Brand 2',
+                variant: 'variant-3',
+                price: '2499',
+                quantity: '1',
+                coupon: 'FLAT10',
+                position: '1'
+              });
+            expect($window.ga).toHaveBeenCalledWith(
+              'tracker2.ec:addProduct',
+              {
+                id: 'sku-2',
+                name: 'Test Product 2',
+                category: 'Category-1',
+                brand: 'Brand 2',
+                variant: 'variant-3',
+                price: '2499',
+                quantity: '1',
+                coupon: 'FLAT10',
+                position: '1'
+              });
+          });
+        });
+      });
+    });
   });
 
   describe('supports arbitrary page events', function () {
@@ -538,7 +614,7 @@ describe('angular-google-analytics universal (analytics.js)', function() {
       AnalyticsProvider.setAccount(trackers);
     }));
 
-    it('should call ga create event for each tracker', function () {
+    it('should call create event for each tracker', function () {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
@@ -550,7 +626,7 @@ describe('angular-google-analytics universal (analytics.js)', function() {
     });
 
     describe('#trackPage', function () {
-      it('should call ga send pageview event for each tracker', function () {
+      it('should call send pageview event for each tracker', function () {
         inject(function ($window) {
           spyOn($window, 'ga');
           inject(function (Analytics) {
@@ -576,7 +652,7 @@ describe('angular-google-analytics universal (analytics.js)', function() {
       AnalyticsProvider.setAccount(trackers);
     }));
 
-    it('should call ga require for each tracker', function () {
+    it('should call require for each tracker', function () {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
@@ -587,7 +663,7 @@ describe('angular-google-analytics universal (analytics.js)', function() {
       });
     });
 
-    it('should call ga linker autoLink for configured tracking objects only', function () {
+    it('should call linker autoLink for configured tracking objects only', function () {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
@@ -598,7 +674,7 @@ describe('angular-google-analytics universal (analytics.js)', function() {
       });
     });
 
-    it ('should call ga create with custom cookie config', function() {
+    it ('should call create with custom cookie config', function() {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -1,43 +1,18 @@
 /* global before, beforeEach, describe, document, expect, inject, it, module, spyOn */
 'use strict';
 
-describe('angular-google-analytics', function() {
+describe('angular-google-analytics universal (analytics.js)', function() {
   beforeEach(module('angular-google-analytics'));
   beforeEach(module(function (AnalyticsProvider) {
     AnalyticsProvider.setAccount('UA-XXXXXX-xx');
+    AnalyticsProvider.useAnalytics(true);
     AnalyticsProvider.logAllCalls(true);
   }));
 
   describe('required settings missing', function () {
-    describe('for default ga script injection', function () {
-      beforeEach(module(function (AnalyticsProvider) {
-        AnalyticsProvider.setAccount(undefined);
-        AnalyticsProvider.useAnalytics(false);
-      }));
-
-      it('should not inject a script tag', function () {
-        inject(function (Analytics) {
-          expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(0);
-        });
-      });
-
-      it('should issue a warning to the log', function () {
-        inject(function ($log) {
-          spyOn($log, 'warn');
-          inject(function (Analytics) {
-            expect(Analytics._logs.length).toBe(1);
-            expect(Analytics._logs[0][0]).toBe('warn');
-            expect(Analytics._logs[0][1]).toBe('No account id set to create script tag');
-            expect($log.warn).toHaveBeenCalledWith(['No account id set to create script tag']);
-          });
-        });
-      });
-    });
-
     describe('for analytics script injection', function () {
       beforeEach(module(function (AnalyticsProvider) {
         AnalyticsProvider.setAccount(undefined);
-        AnalyticsProvider.useAnalytics(true);
       }));
 
       it('should not inject a script tag', function () {
@@ -60,7 +35,7 @@ describe('angular-google-analytics', function() {
     });
   });
 
-  describe('enabled delayedScriptTag', function () {
+  describe('enabled delayed script tag', function () {
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.delayScriptTag(true);
     }));
@@ -73,84 +48,36 @@ describe('angular-google-analytics', function() {
 
     it('should not inject a script tag', function () {
       inject(function (Analytics) {
-        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(0);
-      });
-    });
-
-  });
-
-  describe('automatic trackPages with ga.js', function () {
-    it('should inject the GA script', function () {
-      inject(function (Analytics) {
-        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(1);
-      });
-    });
-
-    it('should generate trackPages', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.trackPage('test');
-        expect(length + 2).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_set', 'title', '']);
-        expect($window._gaq[length + 1]).toEqual(['_trackPageview', 'test']);
-      });
-    });
-
-    it('should generate a trackPage on routeChangeSuccess', function () {
-      inject(function (Analytics, $rootScope, $window) {
-        var length = $window._gaq.length;
-        $rootScope.$broadcast('$routeChangeSuccess');
-        expect(length + 2).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_set', 'title', '']);
-        expect($window._gaq[length + 1]).toEqual(['_trackPageview', '']);
+        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/analytics.js']").length).toBe(0);
       });
     });
   });
 
-  describe('NOT automatic trackPages', function () {
+  describe('create analytics script tag', function () {
     beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.trackPages(false);
+      AnalyticsProvider.delayScriptTag(true);
     }));
 
-    it('should NOT generate a trackpage on routeChangeSuccess', function () {
-      inject(function (Analytics, $rootScope, $window) {
-        var length = $window._gaq.length;
-        $rootScope.$broadcast('$routeChangeSuccess');
-        expect(length).toBe($window._gaq.length);
+    it('should inject a script tag', function () {
+      inject(function (Analytics, $location) {
+        var scriptCount = document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length;
+        Analytics.createAnalyticsScriptTag({ userId: 1234 });
+        expect(Analytics.getCookieConfig().userId).toBe(1234);
+        expect(document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length).toBe(scriptCount + 1);
       });
     });
 
-    it('should generate a trackpage when explicitly called', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.trackPage('/page/here');
-        expect(length + 2).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_set', 'title', '']);
-        expect($window._gaq[length + 1]).toEqual(['_trackPageview', '/page/here']);
-      });
-    });
-  });
-
-  describe('eventTracks with ga.js', function () {
-    beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.trackPages(false);
-    }));
-
-    it('should generate eventTracks', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.trackEvent('test');
-        expect(length + 1).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_trackEvent', 'test', undefined, undefined, undefined, false]);
-      });
-    });
-
-    it('should generate eventTracks with non-interactions', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.trackEvent('test', 'action', 'label', 0, true);
-        expect(length + 1).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_trackEvent', 'test', 'action', 'label', 0, true]);
+    it('should warn and prevent a second attempt to inject a script tag', function () {
+      inject(function ($log) {
+        spyOn($log, 'warn');
+        inject(function (Analytics) {
+          var scriptCount = document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length;
+          Analytics.createAnalyticsScriptTag({ userId: 1234 });
+          expect(document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length).toBe(scriptCount + 1);
+          Analytics.createAnalyticsScriptTag({ userId: 1234 });
+          expect($log.warn).toHaveBeenCalledWith(['ga.js or analytics.js script tag already created']);
+          expect(document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length).toBe(scriptCount + 1);
+        });
       });
     });
   });
@@ -163,38 +90,6 @@ describe('angular-google-analytics', function() {
     it('should inject the DC script', function () {
       inject(function (Analytics) {
         expect(document.querySelectorAll("script[src='http://stats.g.doubleclick.net/dc.js']").length).toBe(1);
-      });
-    });
-  });
-
-  describe('e-commerce transactions', function () {
-    it('should add transcation', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.addTrans('1', '', '2.42', '0.42', '0', 'Amsterdam', '', 'Netherlands');
-        expect(length + 1).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_addTrans', '1', '', '2.42', '0.42', '0', 'Amsterdam', '', 'Netherlands']);
-      });
-    });
-
-    it('should add an item to transaction', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.addItem('1', 'sku-1', 'Test product 1', 'Testing', '1', '1');
-        expect(length + 1).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_addItem', '1', 'sku-1', 'Test product 1', 'Testing', '1', '1']);
-        Analytics.addItem('1', 'sku-2', 'Test product 2', 'Testing', '1', '1');
-        expect(length + 2).toBe($window._gaq.length);
-        expect($window._gaq[length + 1]).toEqual(['_addItem', '1', 'sku-2', 'Test product 2', 'Testing', '1', '1']);
-      });
-    });
-
-    it('should track the transaction', function () {
-      inject(function (Analytics, $window) {
-        var length = $window._gaq.length;
-        Analytics.trackTrans();
-        expect(length + 1).toBe($window._gaq.length);
-        expect($window._gaq[length]).toEqual(['_trackTrans']);
       });
     });
   });
@@ -219,7 +114,6 @@ describe('angular-google-analytics', function() {
     };
 
     beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.useAnalytics(true);
       AnalyticsProvider.setCookieConfig(cookieConfig);
       AnalyticsProvider.useDisplayFeatures(true);
       AnalyticsProvider.useECommerce(true);
@@ -228,8 +122,9 @@ describe('angular-google-analytics', function() {
     }));
 
     it('should inject the Analytics script', function () {
+      var scriptCount = document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length;
       inject(function (Analytics) {
-        expect(document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length).toBe(1);
+        expect(document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length).toBe(scriptCount + 1);
       });
     });
 
@@ -334,7 +229,6 @@ describe('angular-google-analytics', function() {
 
   describe('e-commerce transactions with analytics.js', function () {
     beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.useAnalytics(true);
       AnalyticsProvider.useECommerce(true);
     }));
 
@@ -380,7 +274,6 @@ describe('angular-google-analytics', function() {
 
   describe('enhanced e-commerce transactions with analytics.js', function () {
     beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.useAnalytics(true);
       AnalyticsProvider.useECommerce(true, true);
     }));
 
@@ -549,9 +442,8 @@ describe('angular-google-analytics', function() {
       inject(function (Analytics, $rootScope) {
         var length = Analytics._logs.length;
         $rootScope.$broadcast('$stateChangeSuccess');
-        expect(length + 2).toBe(Analytics._logs.length);
-        expect(Analytics._logs[length][0]).toEqual(['_set', 'title', '']);
-        expect(Analytics._logs[length + 1][0]).toEqual(['_trackPageview', '']);
+        expect(length + 1).toBe(Analytics._logs.length);
+        expect(Analytics._logs[length]).toEqual([ 'send', 'pageview', { page: '', title: '' } ]);
       });
     });
   });
@@ -580,9 +472,8 @@ describe('angular-google-analytics', function() {
         $document[0] = { title: 'title here' };
         var length = Analytics._logs.length;
         Analytics.trackPage();
-        expect(length + 2).toBe(Analytics._logs.length);
-        expect(Analytics._logs[length][0]).toEqual(['_set', 'title', 'title here']);
-        expect(Analytics._logs[length + 1][0]).toEqual(['_trackPageview', '/page/here']);
+        expect(length + 1).toBe(Analytics._logs.length);
+        expect(Analytics._logs[length]).toEqual([ 'send', 'pageview', { page: '/page/here', title: 'title here' } ]);
       });
     });
 
@@ -591,9 +482,8 @@ describe('angular-google-analytics', function() {
         $document[0] = { title: 'title here' };
         var length = Analytics._logs.length;
         Analytics.trackPage('/page/here');
-        expect(length + 2).toBe(Analytics._logs.length);
-        expect(Analytics._logs[length][0]).toEqual(['_set', 'title', 'title here']);
-        expect(Analytics._logs[length + 1][0]).toEqual(['_trackPageview', '/page/here']);
+        expect(length + 1).toBe(Analytics._logs.length);
+        expect(Analytics._logs[length]).toEqual([ 'send', 'pageview', { page: '/page/here', title: 'title here' } ]);
       });
     });
   });
@@ -607,7 +497,6 @@ describe('angular-google-analytics', function() {
 
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.setAccount(trackers);
-      AnalyticsProvider.useAnalytics(true);
     }));
 
     it('should call ga create event for each tracker', function () {
@@ -646,7 +535,6 @@ describe('angular-google-analytics', function() {
 
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.setAccount(trackers);
-      AnalyticsProvider.useAnalytics(true);
     }));
 
     it('should call ga require for each tracker', function () {
@@ -690,7 +578,6 @@ describe('angular-google-analytics', function() {
 
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.setAccount(trackers);
-      AnalyticsProvider.useAnalytics(true);
     }));
 
     it('should track events for configured tracking objects only', function () {
@@ -719,44 +606,7 @@ describe('angular-google-analytics', function() {
     });
   });
 
-  describe('createAnalyticsScriptTag', function () {
-    beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.delayScriptTag(true);
-    }));
-
-    it('should inject a script tag', function () {
-      inject(function (Analytics, $location) {
-        var scriptCount = document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length;
-
-        Analytics.createAnalyticsScriptTag({userId: 1234});
-        expect(Analytics.getCookieConfig().userId).toBe(1234);
-        expect(document.querySelectorAll("script[src='//www.google-analytics.com/analytics.js']").length).toBe(scriptCount + 1);
-      });
-    });
-
-  });
-
-  describe('createAnalyticsScriptTag', function () {
-    beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.delayScriptTag(true);
-    }));
-
-    it('should inject a script tag', function () {
-      inject(function (Analytics, $location) {
-        var scriptCount = document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length;
-        Analytics.createScriptTag({userId: 1234});
-        expect(Analytics.getCookieConfig().userId).toBe(1234);
-        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount + 1);
-      });
-    });
-  });
-
-
   describe('should add user timing', function () {
-    beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.useAnalytics(true);
-    }));
-
     it('should add user timing', function () {
       inject(function (Analytics) {
         var length = Analytics._logs.length;
@@ -766,71 +616,4 @@ describe('angular-google-analytics', function() {
       });
     });
   });
-
-  describe('directives', function () {
-    describe('gaTrackEvent', function () {
-
-      it('should evaluate scope params', function () {
-        inject(function (Analytics, $rootScope, $compile) {
-          spyOn(Analytics, 'trackEvent');
-          var scope = $rootScope.$new(),
-              element = '<div ga-track-event="[event, action, label]">test</div>',
-              compiled = $compile(element)(scope);
-
-          scope.event = 'button';
-          scope.action = 'click';
-          scope.label = 'Some Button';
-
-          scope.$digest();
-          compiled.triggerHandler('click');
-          expect(Analytics.trackEvent).toHaveBeenCalledWith('button', 'click', 'Some Button');
-        });
-      });
-
-      it('should track an event when clicked', function () {
-        inject(function (Analytics, $rootScope, $compile) {
-          spyOn(Analytics, 'trackEvent');
-          var scope = $rootScope.$new(),
-              element = '<div ga-track-event="[\'button\', \'click\', \'Some Button\']">test</div>',
-              compiled = $compile(element)(scope);
-          scope.$digest();
-          compiled.triggerHandler('click');
-          expect(Analytics.trackEvent).toHaveBeenCalledWith('button', 'click', 'Some Button');
-        });
-      });
-
-      it('should inherit parent scope', function () {
-        inject(function (Analytics, $rootScope, $compile) {
-          spyOn(Analytics, 'trackEvent');
-          var scope = $rootScope.$new(), element, compiled;
-          scope.event = ['button', 'click', 'Some Button'];
-          element = '<div ga-track-event="event">test</div>';
-          compiled = $compile(element)(scope);
-          scope.$digest();
-          compiled.triggerHandler('click');
-          expect(Analytics.trackEvent).toHaveBeenCalledWith('button', 'click', 'Some Button');
-        });
-      });
-
-      it('should abort if gaTrackEventIf is false', function () {
-        inject(function (Analytics, $rootScope, $compile) {
-          spyOn(Analytics, 'trackEvent');
-          var scope = $rootScope.$new(),
-              element = '<div ga-track-event="[\'button\', \'click\', \'Some Button\']" ga-track-event-if="false">test</div>',
-              compiled = $compile(element)(scope);
-          scope.$digest();
-          compiled.triggerHandler('click');
-          expect(Analytics.trackEvent.calls.length).toBe(0);
-
-          element = '<div ga-track-event="[\'button\', \'click\', \'Some Button\']" ga-track-event-if="true">test</div>';
-          compiled = $compile(element)(scope);
-          scope.$digest();
-          compiled.triggerHandler('click');
-          expect(Analytics.trackEvent.calls.length).toBe(1);
-        });
-      });
-
-    });
-  });
-
 });


### PR DESCRIPTION
Fix #90 

Split the single monolith test file into three separate files: 'classic', 'universal', and directives. Added tests that could cover both ga.js and analytics.js to both files and updated accordingly. There are now 77 unit tests in total that are passing at 100%.

Encapsulated ecommerce check warnings and added multiple tracker support to all ecommerce and enhanced ecommerce calls. Addition is backwards compatibility with existing behavior of single tracker calls being made. Multiple tracker support only get exhibited when a 'trackEcommerce' property is set to 'true' on any of the tracker objects. There are now 81 unit tests and all are passing at 100%.