### PR TITLE
Add configuration method chaining

### DIFF
--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -42,101 +42,100 @@
           // the trackEvent property must be set to true when there is only a single tracker.
           accounts = [{ tracker: tracker, trackEvent: true }];
         }
-        return true;
+        return this;
       };
 
       this.trackPages = function (doTrack) {
         trackRoutes = doTrack;
-        return true;
+        return this;
       };
 
       this.trackPrefix = function (prefix) {
         trackPrefix = prefix;
-        return true;
+        return this;
       };
 
       this.setDomainName = function (domain) {
         domainName = domain;
-        return true;
+        return this;
       };
 
       this.useDisplayFeatures = function (val) {
         displayFeatures = !!val;
-        return true;
+        return this;
       };
 
       this.useAnalytics = function (val) {
         analyticsJS = !!val;
-        return true;
+        return this;
       };
 
       this.useEnhancedLinkAttribution = function (val) {
         enhancedLinkAttribution = !!val;
-        return true;
+        return this;
       };
 
       this.useCrossDomainLinker = function (val) {
         crossDomainLinker = !!val;
-        return true;
+        return this;
       };
 
       this.setCrossLinkDomains = function (domains) {
         crossLinkDomains = domains;
-        return true;
+        return this;
       };
 
       this.setPageEvent = function (name) {
         pageEvent = name;
-        return true;
+        return this;
       };
 
       this.setCookieConfig = function (config) {
         cookieConfig = config;
-        return true;
+        return this;
       };
 
       this.useECommerce = function (val, enhanced) {
         ecommerce = !!val;
         enhancedEcommerce = !!enhanced;
-        return true;
+        return this;
       };
 
       this.setCurrency = function (currencyCode) {
         currency = currencyCode;
-        return true;
+        return this;
       };
 
       this.setRemoveRegExp = function (regex) {
         if (regex instanceof RegExp) {
           removeRegExp = regex;
-          return true;
         }
-        return false;
+        return this;
       };
 
       this.setExperimentId = function (id) {
         experimentId = id;
-        return true;
+        return this;
       };
 
       this.ignoreFirstPageLoad = function (val) {
         ignoreFirstPageLoad = !!val;
-        return true;
+        return this;
       };
 
       this.trackUrlParams = function (val) {
         trackUrlParams = !!val;
-        return true;
+        return this;
       };
 
       this.delayScriptTag = function (val) {
         delayScriptTag = !!val;
-        return true;
+        return this;
       };
 
       this.logAllCalls = function (val) {
         logAllCalls = !!val;
-        return true;
+        return this;
       };
 
       /**

--- a/test/unit/classic-google-analytics.js
+++ b/test/unit/classic-google-analytics.js
@@ -4,9 +4,10 @@
 describe('angular-google-analytics classic (ga.js)', function() {
   beforeEach(module('angular-google-analytics'));
   beforeEach(module(function (AnalyticsProvider) {
-    AnalyticsProvider.setAccount('UA-XXXXXX-xx');
-    AnalyticsProvider.useAnalytics(false);
-    AnalyticsProvider.logAllCalls(true);
+    AnalyticsProvider
+      .setAccount('UA-XXXXXX-xx')
+      .useAnalytics(false)
+      .logAllCalls(true);
   }));
 
   describe('required settings missing', function () {

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -4,9 +4,10 @@
 describe('angular-google-analytics universal (analytics.js)', function() {
   beforeEach(module('angular-google-analytics'));
   beforeEach(module(function (AnalyticsProvider) {
-    AnalyticsProvider.setAccount('UA-XXXXXX-xx');
-    AnalyticsProvider.useAnalytics(true);
-    AnalyticsProvider.logAllCalls(true);
+    AnalyticsProvider
+      .setAccount('UA-XXXXXX-xx')
+      .useAnalytics(true)
+      .logAllCalls(true);
   }));
 
   describe('required settings missing', function () {
@@ -115,11 +116,12 @@ describe('angular-google-analytics universal (analytics.js)', function() {
     };
 
     beforeEach(module(function (AnalyticsProvider) {
-      AnalyticsProvider.setCookieConfig(cookieConfig);
-      AnalyticsProvider.useDisplayFeatures(true);
-      AnalyticsProvider.useECommerce(true);
-      AnalyticsProvider.useEnhancedLinkAttribution(true);
-      AnalyticsProvider.setExperimentId('12345');
+      AnalyticsProvider
+        .setCookieConfig(cookieConfig)
+        .useDisplayFeatures(true)
+        .useECommerce(true)
+        .useEnhancedLinkAttribution(true)
+        .setExperimentId('12345');
     }));
 
     it('should inject the Analytics script', function () {


### PR DESCRIPTION
Fixes #37. All configuration methods now return the AnalyticsProvider so the methods can be chained together.

Tests are passing 100% with chained configuration methods.

This change will break any usage related to checking the original configuration values for 'true' or in the case of the regex setter, for 'true' or 'false'. I am highly skeptical anyone would ever do that because it would be quite a waste of effort for exactly zero benefit.