### PR TITLE
Use universal analytics by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Proudly brought to you by [@revolunet](http://twitter.com/revolunet), [@deltaeps
 
 ## Features
 
- - configurable
+ - highly configurable
  - automatic page tracking
- - events tracking
- - e-commerce tracking
- - enhanced e-commerce tracking
+ - event tracking
+ - e-commerce (ecommerce.js) support
+ - enhanced e-commerce (ec.js) support
  - multiple-domains
- - ga.js and and analytics.js support
+ - ga.js (classic) and analytics.js (universal) support
  - cross-domain support
  - multiple tracking objects
  - offline mode
@@ -35,11 +35,11 @@ app.config(function (AnalyticsProvider) {
 });
 ```
 
-### Use Universal Analytics
+### Use Classic Analytics
 ```js
-// Use analytics.js (universal) instead of ga.js (classic)
-// By default, classic analytics is used, unless this is called with a truthy value.
-AnalyticsProvider.useAnalytics(true);
+// Use ga.js (classic) instead of analytics.js (universal)
+// By default, universal analytics is used, unless this is called with a falsey value.
+AnalyticsProvider.useAnalytics(false);
 ```
 
 ### Set Google Analytics Accounts (Required)
@@ -141,9 +141,13 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
   // Enable e-commerce module (ecommerce.js)
   AnalyticsProvider.useECommerce(true, false);
 
-  // Enabled enhanced e-commerce module (ec.js)
+  // Enable enhanced e-commerce module (ec.js)
   // Universal Analytics only
   AnalyticsProvider.useECommerce(true, true);
+
+  // Set Currency
+  // Default is 'USD'. Use ISO currency codes.
+  AnalyticsProvider.setCurrency('CDN');
 ```
 **Note:** When enhanced e-commerce is enabled, the legacy e-commerce module is disabled and unsupported. This is a requirement of Google Analytics.
 
@@ -222,6 +226,56 @@ If you are relying on automatic page tracking, you need to inject Analytics at l
   app.controller('SampleController', function (Analytics) {
     // Add calls as desired - see below
   });
+```
+
+### Accessing Configuration Settings
+The following configuration settings are intended to be immutable. While the values can be changed in this list by the user, this will not impact the behavior of the service as these values are not referenced internally; exceptions are noted below but are not intended to be utilized in such a way by the user. No guarantee will be made for future versions of this service supporting any functionality beyond reading values from this list.
+```js
+  // This is a mutable array. Changes to this list will impact service behaviors.
+  Analytics.configuration.accounts;
+
+  // If `true` then universal analytics is being used.
+  // If `false` then classic analytics is being used.
+  Analytics.configuration.universalAnalytics;
+
+  Analytics.configuration.crossDomainLinker;
+  Analytics.configuration.crossLinkDomains;
+  Analytics.configuration.currency;
+  Analytics.configuration.delayScriptTag;
+  Analytics.configuration.displayFeatures;
+  Analytics.configuration.domainName;
+
+  // ecommerce and enhancedEcommerce are mutually exclusive; either both will be false or one will be true.
+  Analytics.configuration.ecommerce;
+  Analytics.configuration.enhancedEcommerce;
+
+  Analytics.configuration.enhancedLinkAttribution;
+  Analytics.configuration.experimentId;
+  Analytics.configuration.ignoreFirstPageLoad;
+  Analytics.configuration.logAllCalls;
+  Analytics.configuration.pageEvent;
+  Analytics.configuration.removeRegExp;
+  Analytics.configuration.trackPrefix;
+  Analytics.configuration.trackRoutes;
+  Analytics.configuration.trackUrlParams;
+```
+
+### Get or Set Cookie Configuration
+```js
+  // Get the global cookie config.
+  Analytics.getCookieConfig();
+
+  // Set the global cookie config.
+  // Impacts all future calls for classic analytics (ga.js).
+  Analytics.setCookieConfig();
+```
+**Note:** Changing the cookie configuration after the AnalyticsProvider configuration only works for classic analytics (ga.js). This does not update the individual account objects used by universal analytics (analytics.js). If you want to change the account objects used by universal analytics those can be accessed through `Analytics.configuration.accounts`, but such modification to the accounts object is unsupported.
+
+### Get URL
+```js
+  // Returns the current URL that would be sent if a `trackPage` call was made.
+  // The returned value takes into account all configuration settings that modify the URL.
+  Analytics.getUrl();
 ```
 
 ### Manual Script Tag Injection

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -3,7 +3,7 @@
   angular.module('angular-google-analytics', [])
     .provider('Analytics', function () {
       var accounts,
-          analyticsJS = false,
+          analyticsJS = true,
           cookieConfig = 'auto',
           created = false,
           crossDomainLinker = false,
@@ -816,6 +816,15 @@
         };
 
         /**
+         * Track detail
+         * @private
+         */
+        this._trackDetail = function () {
+          this._setAction('detail');
+          this._pageView();
+        };
+
+        /**
          * Track add/remove to cart
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#add-remove-cart
          * @param action
@@ -920,15 +929,28 @@
 
         return {
           log: that.log,
-          accounts: accounts,
-          displayFeatures: displayFeatures,
-          ecommerce: ecommerce,
-          enhancedEcommerce: enhancedEcommerce,
-          enhancedLinkAttribution: enhancedLinkAttribution,
+          configuration: {
+            accounts: accounts,
+            universalAnalytics: analyticsJS,
+            crossDomainLinker: crossDomainLinker,
+            crossLinkDomains: crossLinkDomains,
+            currency: currency,
+            delayScriptTag: delayScriptTag,
+            displayFeatures: displayFeatures,
+            domainName: domainName,
+            ecommerce: that._ecommerceEnabled(),
+            enhancedEcommerce: that._enhancedEcommerceEnabled(),
+            enhancedLinkAttribution: enhancedLinkAttribution,
+            experimentId: experimentId,
+            ignoreFirstPageLoad: ignoreFirstPageLoad,
+            logAllCalls: logAllCalls,
+            pageEvent: pageEvent,
+            removeRegExp: removeRegExp,
+            trackPrefix: trackPrefix,
+            trackRoutes: trackRoutes,
+            trackUrlParams: trackUrlParams
+          },
           getUrl: getUrl,
-          experimentId: experimentId,
-          ignoreFirstPageLoad: ignoreFirstPageLoad,
-          delayScriptTag: delayScriptTag,
           setCookieConfig: that._setCookieConfig,
           getCookieConfig: function () {
             return cookieConfig;
@@ -961,12 +983,6 @@
               }
             }
             return offlineMode;
-          },
-          ecommerceEnabled: function () {
-            return that._ecommerceEnabled();
-          },
-          enhancedEcommerceEnabled: function () {
-            return that._enhancedEcommerceEnabled();
           },
           trackPage: function (url, title, custom) {
             that._trackPage(url, title, custom);
@@ -1002,8 +1018,7 @@
             that._promoClick(promotionName);
           },
           trackDetail: function () {
-            that._setAction('detail');
-            that._pageView();
+            that._trackDetail();
           },
           trackCart: function (action) {
             that._trackCart(action);
@@ -1020,14 +1035,14 @@
           setAction: function (action, obj) {
             that._setAction(action, obj);
           },
-          send: function (obj) {
-            that._send(obj);
-          },
           pageView: function () {
             that._pageView();
           },
-          set: function (name, value) {
-            that._set(name, value);
+          send: function (obj) {
+            that._send(obj);
+          },
+          set: function (name, value, trackerName) {
+            that._set(name, value, trackerName);
           }
         };
       }];

--- a/test/unit/classic-google-analytics.js
+++ b/test/unit/classic-google-analytics.js
@@ -17,8 +17,9 @@ describe('angular-google-analytics classic (ga.js)', function() {
       }));
 
       it('should not inject a script tag', function () {
+        var scriptCount = document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length;
         inject(function (Analytics) {
-          expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(0);
+          expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount);
         });
       });
 
@@ -42,13 +43,14 @@ describe('angular-google-analytics classic (ga.js)', function() {
 
     it('should have a truthy value for Analytics.delayScriptTag', function () {
       inject(function (Analytics, $location) {
-        expect(Analytics.delayScriptTag).toBe(true);
+        expect(Analytics.configuration.delayScriptTag).toBe(true);
       });
     });
 
     it('should not inject a script tag', function () {
+      var scriptCount = document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length;
       inject(function (Analytics) {
-        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(0);
+        expect(document.querySelectorAll("script[src='http://www.google-analytics.com/ga.js']").length).toBe(scriptCount);
       });
     });
   });
@@ -232,7 +234,7 @@ describe('angular-google-analytics classic (ga.js)', function() {
 
     it('supports ignoreFirstPageLoad config', function () {
       inject(function (Analytics, $rootScope) {
-        expect(Analytics.ignoreFirstPageLoad).toBe(true);
+        expect(Analytics.configuration.ignoreFirstPageLoad).toBe(true);
       });
     });
   });

--- a/test/unit/offline-mode.js
+++ b/test/unit/offline-mode.js
@@ -27,7 +27,7 @@ describe('angular-google-analytics offline mode', function () {
 
       it('should have delay script tag set to true', function () {
         inject(function (Analytics) {
-          expect(Analytics.delayScriptTag).toBe(true);
+          expect(Analytics.configuration.delayScriptTag).toBe(true);
         });
       });
 
@@ -115,7 +115,7 @@ describe('angular-google-analytics offline mode', function () {
 
       it('should have delay script tag set to true', function () {
         inject(function (Analytics) {
-          expect(Analytics.delayScriptTag).toBe(true);
+          expect(Analytics.configuration.delayScriptTag).toBe(true);
         });
       });
 

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -43,7 +43,7 @@ describe('angular-google-analytics universal (analytics.js)', function () {
 
     it('should have a truthy value for Analytics.delayScriptTag', function () {
       inject(function (Analytics, $location) {
-        expect(Analytics.delayScriptTag).toBe(true);
+        expect(Analytics.configuration.delayScriptTag).toBe(true);
       });
     });
 
@@ -103,7 +103,7 @@ describe('angular-google-analytics universal (analytics.js)', function () {
 
     it('supports ignoreFirstPageLoad config', function () {
       inject(function (Analytics, $rootScope) {
-        expect(Analytics.ignoreFirstPageLoad).toBe(true);
+        expect(Analytics.configuration.ignoreFirstPageLoad).toBe(true);
       });
     });
   });
@@ -139,25 +139,25 @@ describe('angular-google-analytics universal (analytics.js)', function () {
 
     it('should support displayFeatures config', function () {
       inject(function (Analytics) {
-        expect(Analytics.displayFeatures).toBe(true);
+        expect(Analytics.configuration.displayFeatures).toBe(true);
       });
     });
 
     it('should support ecommerce config', function () {
       inject(function (Analytics) {
-        expect(Analytics.ecommerce).toBe(true);
+        expect(Analytics.configuration.ecommerce).toBe(true);
       });
     });
 
     it('should support enhancedLinkAttribution config', function () {
       inject(function (Analytics) {
-        expect(Analytics.enhancedLinkAttribution).toBe(true);
+        expect(Analytics.configuration.enhancedLinkAttribution).toBe(true);
       });
     });
 
     it('should support experimentId config', function () {
       inject(function (Analytics) {
-        expect(Analytics.experimentId).toBe('12345');
+        expect(Analytics.configuration.experimentId).toBe('12345');
       });
     });
 
@@ -237,13 +237,13 @@ describe('angular-google-analytics universal (analytics.js)', function () {
 
     it('should have ecommerce enabled', function () {
       inject(function (Analytics) {
-        expect(Analytics.ecommerceEnabled()).toBe(true);
+        expect(Analytics.configuration.ecommerce).toBe(true);
       });
     });
 
     it('should have enhanced ecommerce disabled', function () {
       inject(function (Analytics) {
-        expect(Analytics.enhancedEcommerceEnabled()).toBe(false);
+        expect(Analytics.configuration.enhancedEcommerce).toBe(false);
       });
     });
 
@@ -326,13 +326,13 @@ describe('angular-google-analytics universal (analytics.js)', function () {
 
     it('should have ecommerce disabled', function () {
       inject(function (Analytics) {
-        expect(Analytics.ecommerceEnabled()).toBe(false);
+        expect(Analytics.configuration.ecommerce).toBe(false);
       });
     });
 
     it('should have enhanced ecommerce enabled', function () {
       inject(function (Analytics) {
-        expect(Analytics.enhancedEcommerceEnabled()).toBe(true);
+        expect(Analytics.configuration.enhancedEcommerce).toBe(true);
       });
     });
 
@@ -702,6 +702,28 @@ describe('angular-google-analytics universal (analytics.js)', function () {
           expect($window.ga).toHaveBeenCalledWith('tracker1.send', 'event', 'category', 'action', 'label', 'value', {});
           expect($window.ga).not.toHaveBeenCalledWith('tracker2.send', 'event', 'category', 'action', 'label', 'value', {});
           expect($window.ga).toHaveBeenCalledWith('send', 'event', 'category', 'action', 'label', 'value', {});
+        });
+      });
+    });
+  });
+
+  describe('supports advanced settings', function () {
+    it('should set value for default tracker if no trackerName provided', function () {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          Analytics.set('dimension1', 'metric1');
+          expect($window.ga).toHaveBeenCalledWith('set', 'dimension1', 'metric1');
+        });
+      });
+    });
+
+    it('should set value for named tracker if a trackerName provided', function () {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          Analytics.set('dimension2', 'metric2', 'tracker1');
+          expect($window.ga).toHaveBeenCalledWith('tracker1.set', 'dimension2', 'metric2');
         });
       });
     });


### PR DESCRIPTION
Fix #68, #91

* universal analytics is now the default option.
* set method now exposes a trackerName parameter.
* put configuration values into an exposed object off of the Analytics service.
* Add missing methods and properties to README.