### PR TITLE
Fix bug with fields support on create method

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,15 @@ Enhanced e-commerce is only available for universal analytics. Enhanced e-commer
 
 #### Product Click Tracking
 ```js
-  Analytics.addProduct(productId, name, category, brand, variant, price, quantity, coupon, position);
+  Analytics.addProduct(productId, name, category, brand, variant, price, quantity, coupon, position, custom);
   Analytics.productClick(listName);
 
   // example:
   Analytics.addProduct('sku-2', 'Test Product 2', 'Category-1', 'Brand 2', 'variant-3', '2499', '1', 'FLAT10', '1');
+  Analytics.productClick('Search Result');
+
+  // example with custom dimension and metric:
+  Analytics.addProduct('sku-2', 'Test Product 2', 'Category-1', 'Brand 2', 'variant-3', '2499', '1', 'FLAT10', '1', { dimension4: 'strong', metric2: 5 });
   Analytics.productClick('Search Result');
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ AnalyticsProvider.setAccount([
 AnalyticsProvider.setAccount({
   tracker: 'UA-12345-12',
   name: "tracker1",
-  cookieConfig: {
+  fields: {
     cookieDomain: 'foo.example.com',
     cookieName: 'myNewName',
     cookieExpires: 20000
+    // See: [Analytics Field Reference](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference) for a list of all fields
   },
   crossDomainLinker: true,
   crossLinkDomains: ['domain-1.com', 'domain-2.com'],
@@ -89,6 +90,7 @@ AnalyticsProvider.setAccount({
 });
 ```
 **Note:** the above properties are referenced and discussed in proceeding sections.
+**Note:** the `cookieConfig` property is being **deprecated** for the `fields` property. At present `cookieConfig` is an alias for `fields` in an account object.
 
 ### Use Display Features
 ```js
@@ -122,6 +124,9 @@ If set to a truthy value then the cross-linked domains are registered with Googl
 In the case of universal analytics, these values will be used as the default for any tracker that does not have the `crossDomainLinker` and `crossLinkDomains` properties defined. All trackers with `crossDomainLinker: true` will register the cross-linked domains.
 
 ### Set Cookie Configuration
+**NOTE:** This method is being **deprecated**. Use the `fields` property on the account object instead.
+This property is defined for universal analytics account objects only and is set to `auto` by default.
+
 ```js
   // Set custom cookie parameters
   AnalyticsProvider.setCookieConfig({
@@ -130,7 +135,7 @@ In the case of universal analytics, these values will be used as the default for
     cookieExpires: 20000
   });
 ```
-In the case of universal analytics, this cookie configuration will be used as the default for any tracker that does not have the `cookieConfig` property defined.
+This cookie configuration will be used as the default for any tracker that does not have the `cookieConfig` property defined.
 
 ### Track Events
 This property is defined for universal analytics account objects only and is false by default.
@@ -280,6 +285,8 @@ The following configuration settings are intended to be immutable. While the val
 ```
 
 ### Get or Set Cookie Configuration
+**NOTE:** These methods are being **deprecated**. Use the `fields` property on the account object instead.
+
 ```js
   // Get the global cookie config.
   Analytics.getCookieConfig();
@@ -288,7 +295,7 @@ The following configuration settings are intended to be immutable. While the val
   // Impacts all future calls for classic analytics (ga.js).
   Analytics.setCookieConfig();
 ```
-**Note:** Changing the cookie configuration after the AnalyticsProvider configuration only works for classic analytics (ga.js). This does not update the individual account objects used by universal analytics (analytics.js). If you want to change the account objects used by universal analytics those can be accessed through `Analytics.configuration.accounts`, but such modification to the accounts object is unsupported.
+**Note:** Changing the cookie configuration after the AnalyticsProvider configuration does not update the individual account objects used by universal analytics (analytics.js). If you want to change the account objects used by universal analytics those can be accessed through `Analytics.configuration.accounts`, but such modification to the accounts object is unsupported.
 
 ### Get URL
 ```js
@@ -301,10 +308,10 @@ The following configuration settings are intended to be immutable. While the val
 If `delayScriptTag(true)` was set during configuration then manual script tag injection is required. Otherwise, the script tag will be automatically injected and configured when the service is instantiated.
 ```js
   // Manually create classic analytics (ga.js) script tag
-  Analytics.createScriptTag({ userId: 1234 });
+  Analytics.createScriptTag();
 
   // Manually create universal analytics (analytics.js) script tag
-  Analytics.createAnalyticsScriptTag({ userId: 1234 });
+  Analytics.createAnalyticsScriptTag();
 ```
 
 ### Advanced Settings / Custom Dimensions

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -683,7 +683,7 @@
          */
 
         /**
-         * Add product data
+         * Add Product
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#product-data
          * @param productId
          * @param name
@@ -694,9 +694,10 @@
          * @param quantity
          * @param coupon
          * @param position
+         * @param custom
          * @private
          */
-        this._addProduct = function (productId, name, category, brand, variant, price, quantity, coupon, position) {
+        this._addProduct = function (productId, name, category, brand, variant, price, quantity, coupon, position, custom) {
           _gaJs(function () {
             _gaq('_addProduct', productId, name, category, brand, variant, price, quantity, coupon, position);
           });
@@ -705,27 +706,27 @@
               var includeFn = function (trackerObj) {
                 return isPropertySetTo('trackEcommerce', trackerObj, true);
               };
-
-              _gaMultipleTrackers(
-                includeFn,
-                'ec:addProduct',
-                {
-                  id: productId,
-                  name: name,
-                  category: category,
-                  brand: brand,
-                  variant: variant,
-                  price: price,
-                  quantity: quantity,
-                  coupon: coupon,
-                  position: position
-                });
+              var details = {
+                id: productId,
+                name: name,
+                category: category,
+                brand: brand,
+                variant: variant,
+                price: price,
+                quantity: quantity,
+                coupon: coupon,
+                position: position
+              };
+              if (angular.isObject(custom)) {
+                angular.extend(details, custom);
+              }
+              _gaMultipleTrackers(includeFn, 'ec:addProduct', details);
             }
           });
         };
 
         /**
-         * Add Impression data
+         * Add Impression
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#impression-data
          * @param id
          * @param name
@@ -765,7 +766,7 @@
         };
 
         /**
-         * Add promo data
+         * Add Promo
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce
          * @param productId
          * @param name
@@ -797,7 +798,7 @@
         };
 
         /**
-         * Set Action being performed
+         * Set Action
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#measuring-actions
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/enhanced-ecommerce#action-types
          * @param action
@@ -1027,64 +1028,64 @@
             return offlineMode;
           },
           trackPage: function (url, title, custom) {
-            that._trackPage(url, title, custom);
+            that._trackPage.apply(that, arguments);
           },
           trackEvent: function (category, action, label, value, noninteraction, custom) {
-            that._trackEvent(category, action, label, value, noninteraction, custom);
+            that._trackEvent.apply(that, arguments);
           },
           addTrans: function (transactionId, affiliation, total, tax, shipping, city, state, country, currency) {
-            that._addTrans(transactionId, affiliation, total, tax, shipping, city, state, country, currency);
+            that._addTrans.apply(that, arguments);
           },
           addItem: function (transactionId, sku, name, category, price, quantity) {
-            that._addItem(transactionId, sku, name, category, price, quantity);
+            that._addItem.apply(that, arguments);
           },
           trackTrans: function () {
-            that._trackTrans();
+            that._trackTrans.apply(that, arguments);
           },
           clearTrans: function () {
-            that._clearTrans();
+            that._clearTrans.apply(that, arguments);
           },
-          addProduct: function (productId, name, category, brand, variant, price, quantity, coupon, position) {
-            that._addProduct(productId, name, category, brand, variant, price, quantity, coupon, position);
+          addProduct: function (productId, name, category, brand, variant, price, quantity, coupon, position, custom) {
+            that._addProduct.apply(that, arguments);
           },
           addPromo: function (productId, name, creative, position) {
-            that._addPromo(productId, name, creative, position);
+            that._addPromo.apply(that, arguments);
           },
           addImpression: function (productId, name, list, brand, category, variant, position, price) {
-            that._addImpression(productId, name, list, brand, category, variant, position, price);
+            that._addImpression.apply(that, arguments);
           },
           productClick: function (listName) {
-            that._productClick(listName);
+            that._productClick.apply(that, arguments);
           },
           promoClick : function (promotionName) {
-            that._promoClick(promotionName);
+            that._promoClick.apply(that, arguments);
           },
           trackDetail: function () {
-            that._trackDetail();
+            that._trackDetail.apply(that, arguments);
           },
           trackCart: function (action) {
-            that._trackCart(action);
+            that._trackCart.apply(that, arguments);
           },
           trackCheckout: function (step, option) {
-            that._trackCheckOut(step, option);
+            that._trackCheckOut.apply(that, arguments);
           },
           trackTimings: function (timingCategory, timingVar, timingValue, timingLabel) {
-            that._trackTimings(timingCategory, timingVar, timingValue, timingLabel);
+            that._trackTimings.apply(that, arguments);
           },
           trackTransaction: function (transactionId, affiliation, revenue, tax, shipping, coupon, list, step, option){
-            that._trackTransaction(transactionId, affiliation, revenue, tax, shipping, coupon, list, step, option);
+            that._trackTransaction.apply(that, arguments);
           },
           setAction: function (action, obj) {
-            that._setAction(action, obj);
+            that._setAction.apply(that, arguments);
           },
           pageView: function () {
-            that._pageView();
+            that._pageView.apply(that, arguments);
           },
           send: function (obj) {
-            that._send(obj);
+            that._send.apply(that, arguments);
           },
           set: function (name, value, trackerName) {
-            that._set(name, value, trackerName);
+            that._set.apply(that, arguments);
           }
         };
       }];

--- a/test/unit/classic-google-analytics.js
+++ b/test/unit/classic-google-analytics.js
@@ -89,9 +89,8 @@ describe('classic analytics', function() {
 
     it('should inject a script tag', function () {
       inject(function (Analytics) {
-        Analytics.createScriptTag({ userId: 1234 });
+        Analytics.createScriptTag();
         expect(Analytics.log[Analytics.log.length - 1]).toEqual(['inject', 'http://www.google-analytics.com/ga.js']);
-        expect(Analytics.getCookieConfig().userId).toBe(1234);
         expect(document.querySelectorAll('script[src="//www.google-analytics.com/analytics.js"]').length).toBe(0);
       });
     });

--- a/test/unit/offline-mode.js
+++ b/test/unit/offline-mode.js
@@ -49,7 +49,7 @@ describe('offline mode', function () {
           Analytics.offline(false);
           expect(Analytics.log.length).toBe(3);
           expect(Analytics.log[0]).toEqual(['inject', '//www.google-analytics.com/analytics.js']);
-          expect(Analytics.log[1]).toEqual(['create', 'UA-XXXXXX-xx', 'auto', { allowLinker : false }]);
+          expect(Analytics.log[1]).toEqual(['create', 'UA-XXXXXX-xx', { cookieDomain: 'auto' }]);
           expect(Analytics.log[2]).toEqual(['send', 'pageview', '']);
         });
       });

--- a/test/unit/scenarios.js
+++ b/test/unit/scenarios.js
@@ -22,7 +22,7 @@ describe('universal analytics scenarios', function () {
       inject(function (Analytics) {
         var i, count, expected = [
           ['inject', '//www.google-analytics.com/analytics.js'], // This entry is in the log only due to test mode
-          ['create', 'UA-XXXXXX-xx', 'auto', {allowLinker: false}],
+          ['create', 'UA-XXXXXX-xx', { cookieDomain: 'auto' }],
           ['require', 'ec'],
           ['set', '&cu', 'EUR'],
           ['send', 'pageview', ''],

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -639,9 +639,9 @@ describe('universal analytics', function () {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
-          expect($window.ga).toHaveBeenCalledWith('create', trackers[0].tracker, 'auto', { allowLinker: false, name: trackers[0].name });
-          expect($window.ga).toHaveBeenCalledWith('create', trackers[1].tracker, 'auto', { allowLinker: false, name: trackers[1].name });
-          expect($window.ga).toHaveBeenCalledWith('create', trackers[2].tracker, 'auto', { allowLinker: false });
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[0].tracker, { cookieDomain: 'auto', name: trackers[0].name });
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[1].tracker, { cookieDomain: 'auto', name: trackers[1].name });
+          expect($window.ga).toHaveBeenCalledWith('create', trackers[2].tracker, { cookieDomain: 'auto' });
         });
       });
     });
@@ -697,7 +697,7 @@ describe('universal analytics', function () {
       inject(function ($window) {
         spyOn($window, 'ga');
         inject(function (Analytics) {
-          expect($window.ga).toHaveBeenCalledWith('create', 'UA-12345-67', 'yourdomain.org', { allowLinker: false });
+          expect($window.ga).toHaveBeenCalledWith('create', 'UA-12345-67', { cookieDomain: 'yourdomain.org' });
         });
       });
     });

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -391,6 +391,31 @@ describe('universal analytics', function () {
       });
     });
 
+    it('should add product data with custom properties', function () {
+      inject(function ($window) {
+        spyOn($window, 'ga');
+        inject(function (Analytics) {
+          Analytics.log.length = 0; // clear log
+          Analytics.addProduct('sku-2', 'Test Product 2', 'Category-1', 'Brand 2', 'variant-3', '2499', '1', undefined, undefined, { dimension1: '1' });
+          expect(Analytics.log.length).toBe(1);
+          expect($window.ga).toHaveBeenCalledWith(
+            'ec:addProduct',
+            {
+              id: 'sku-2',
+              name: 'Test Product 2',
+              category: 'Category-1',
+              brand: 'Brand 2',
+              variant: 'variant-3',
+              price: '2499',
+              quantity: '1',
+              coupon: undefined,
+              position: undefined,
+              dimension1: '1'
+            });
+        });
+      });
+    });
+
     it('should add promo data', function () {
       inject(function (Analytics) {
         Analytics.log.length = 0; // clear log


### PR DESCRIPTION
Fixes #65 - addProduct now supports custom properties (dimensions and metrics)
Additionally:
* The call to GA create was being incorrectly formatted if object values were being supplied for both cookieConfig and the options. All of these properties are defined as fields in the GA documentation and can be sent together in one object.
* All methods and properties related to cookieConfig have been marked as deprecated and will be removed in a future release.
* cookieConfig is also not supported by classic analytics and has been corrected in the implementation and documentation as such.