### PR TITLE
Add hybrid mobile application support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Proudly brought to you by [@revolunet](http://twitter.com/revolunet), [@deltaeps
  - ga.js (classic) and analytics.js (universal) support
  - cross-domain support
  - multiple tracking objects
+ - hybrid mobile application support
  - offline mode
 
 ## Installation
@@ -217,6 +218,16 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
   AnalyticsProvider.setExperimentId('12345');
 ```
 **Note:** only a single experiment can be defined.
+
+### Support Hybrid Mobile Applications
+This property is defined for universal analytics only and is false by default.
+
+```js
+  // Set hybrid mobile application support
+  AnalyticsProvider.setHybridMobileSupport(true);
+```
+
+If set to a truthy value then each account object will disable protocol checking and all injected scripts will use the HTTPS protocol.
 
 ### Delay Script Tag Insertion
 ```js

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -18,6 +18,7 @@
           experimentId,
           ignoreFirstPageLoad = false,
           logAllCalls = false,
+          hybridMobileSupport = false,
           offlineMode = false,
           pageEvent = '$routeChangeSuccess',
           removeRegExp,
@@ -129,6 +130,11 @@
 
       this.trackUrlParams = function (val) {
         trackUrlParams = !!val;
+        return this;
+      };
+
+      this.setHybridMobileSupport = function (val) {
+        hybridMobileSupport = !!val;
         return this;
       };
 
@@ -393,7 +399,8 @@
             return;
           }
 
-          var scriptSource = '//www.google-analytics.com/analytics.js';
+          var protocol = hybridMobileSupport === true ? 'https:' : '';
+          var scriptSource = protocol + '//www.google-analytics.com/analytics.js';
           if (testMode !== true) {
             // If not in test mode inject the Google Analytics tag
             (function (i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function (){
@@ -417,7 +424,7 @@
             trackerObj.trackEcommerce = isPropertyDefined('trackEcommerce', trackerObj) ? trackerObj.trackEcommerce : ecommerce;
             trackerObj.trackEvent = isPropertyDefined('trackEvent', trackerObj) ? trackerObj.trackEvent : false;
 
-            // Logic to choose what account fields to be used.
+            // Logic to choose the account fields to be used.
             // cookieConfig is being deprecated for a tracker specific property: fields.
             var fields = {};
             if (isPropertyDefined('fields', trackerObj)) {
@@ -442,6 +449,12 @@
             trackerObj.fields = fields;
 
             _ga('create', trackerObj.tracker, trackerObj.fields);
+
+            // Hybrid mobile application support
+            // https://developers.google.com/analytics/devguides/collection/analyticsjs/tasks
+            if (hybridMobileSupport === true) {
+              _ga(generateCommandName('set', trackerObj), 'checkProtocolTask', null);
+            }
 
             if (trackerObj.crossDomainLinker === true) {
               _ga(generateCommandName('require', trackerObj), 'linker');
@@ -475,7 +488,7 @@
           if (experimentId) {
             var expScript = document.createElement('script'),
                 s = document.getElementsByTagName('script')[0];
-            expScript.src = '//www.google-analytics.com/cx/api.js?experiment=' + experimentId;
+            expScript.src = protocol + '//www.google-analytics.com/cx/api.js?experiment=' + experimentId;
             s.parentNode.insertBefore(expScript, s);
           }
 
@@ -988,6 +1001,7 @@
             enhancedEcommerce: that._enhancedEcommerceEnabled(),
             enhancedLinkAttribution: enhancedLinkAttribution,
             experimentId: experimentId,
+            hybridMobileSupport: hybridMobileSupport,
             ignoreFirstPageLoad: ignoreFirstPageLoad,
             logAllCalls: logAllCalls,
             pageEvent: pageEvent,

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -116,6 +116,30 @@ describe('universal analytics', function () {
     });
   });
 
+  describe('hybrid mobile application support', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider
+        .setHybridMobileSupport(true)
+        .delayScriptTag(true);
+    }));
+
+    it('should support hybridMobileSupport', function () {
+      inject(function (Analytics) {
+        expect(Analytics.configuration.hybridMobileSupport).toBe(true);
+      });
+    });
+
+    it('should inject a script tag with the HTTPS protocol and set checkProtocolTask to null', function () {
+      inject(function (Analytics) {
+        Analytics.log.length = 0; // clear log
+        Analytics.createAnalyticsScriptTag();
+        expect(Analytics.log[0]).toEqual(['inject', 'https://www.google-analytics.com/analytics.js']);
+        expect(Analytics.log[1]).toEqual(['create', 'UA-XXXXXX-xx', { cookieDomain: 'auto' }]);
+        expect(Analytics.log[2]).toEqual(['set', 'checkProtocolTask', null]);
+      });
+    });
+  });
+
   describe('ignoreFirstPageLoad configuration support', function () {
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.ignoreFirstPageLoad(true);


### PR DESCRIPTION
Fixes #31, #113

Hybrid mobile applications require the protocol for script fetching to be set to HTTPS and require the checkProtocolTask to be set to null for each account object.