### PR TITLE
Add support for custom set commands on accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ AnalyticsProvider.setAccount({
   crossLinkDomains: ['domain-1.com', 'domain-2.com'],
   displayFeatures: true,
   enhancedLinkAttribution: true,
+  select: function (args) {
+    // This function is used to qualify or disqualify an account object to be run with commands.
+    // If the function does not exist, is not a function, or returns true then the account object will qualify.
+    // If the function exists and returns false then the account object will be disqualified.
+    // The 'args' parameter is the set of arguments (which contains the command name) that will be sent to Universal Analytics.
+    return true;
+  },
   set: {
     forceSSL: true
     // This is any set of `set` commands to make for the account immediately after the `create` command for the account.

--- a/README.md
+++ b/README.md
@@ -93,12 +93,18 @@ AnalyticsProvider.setAccount({
     cookieDomain: 'foo.example.com',
     cookieName: 'myNewName',
     cookieExpires: 20000
-    // See: [Analytics Field Reference](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference) for a list of all fields
+    // See: [Analytics Field Reference](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference) for a list of all fields.
   },
   crossDomainLinker: true,
   crossLinkDomains: ['domain-1.com', 'domain-2.com'],
   displayFeatures: true,
   enhancedLinkAttribution: true,
+  set: {
+    forceSSL: true
+    // This is any set of `set` commands to make for the account immediately after the `create` command for the account.
+    // The property key is the command and the property value is passed in as the argument, _e.g._, `ga('set', 'forceSSL', true)`.
+    // Order of commands is not guaranteed as it is dependent on the implementation of the `for (property in object)` iterator.
+  },
   trackEvent: true,
   trackEcommerce: true
 });

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -311,6 +311,11 @@
           }
 
           trackers.forEach(function (tracker) {
+            // Check tracker 'select' function, if it exists, for whether the tracker should be used with the current command.
+            // If the 'select' function returns false then the tracker will not be used with the current command.
+            if (isPropertyDefined('select', tracker) && typeof tracker.select === 'function' && !tracker.select(args)) {
+              return;
+            }
             args[0] = generateCommandName(commandName, tracker);
             _ga.apply(that, args);
           });

--- a/src/angular-google-analytics.js
+++ b/src/angular-google-analytics.js
@@ -421,6 +421,7 @@
             trackerObj.crossLinkDomains = isPropertyDefined('crossLinkDomains', trackerObj) ? trackerObj.crossLinkDomains : crossLinkDomains;
             trackerObj.displayFeatures = isPropertyDefined('displayFeatures', trackerObj) ? trackerObj.displayFeatures : displayFeatures;
             trackerObj.enhancedLinkAttribution = isPropertyDefined('enhancedLinkAttribution', trackerObj) ? trackerObj.enhancedLinkAttribution : enhancedLinkAttribution;
+            trackerObj.set = isPropertyDefined('set', trackerObj) ? trackerObj.set : {};
             trackerObj.trackEcommerce = isPropertyDefined('trackEcommerce', trackerObj) ? trackerObj.trackEcommerce : ecommerce;
             trackerObj.trackEvent = isPropertyDefined('trackEvent', trackerObj) ? trackerObj.trackEvent : false;
 
@@ -454,6 +455,13 @@
             // https://developers.google.com/analytics/devguides/collection/analyticsjs/tasks
             if (hybridMobileSupport === true) {
               _ga(generateCommandName('set', trackerObj), 'checkProtocolTask', null);
+            }
+
+            // Send all custom set commands from the trackerObj.set property
+            for (var key in trackerObj.set) {
+              if (trackerObj.set.hasOwnProperty(key)) {
+                _ga(generateCommandName('set', trackerObj), key, trackerObj.set[key]);
+              }
             }
 
             if (trackerObj.crossDomainLinker === true) {

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -165,6 +165,30 @@ describe('universal analytics', function () {
     });
   });
 
+  describe('account select support', function () {
+    var account;
+
+    beforeEach(module(function (AnalyticsProvider) {
+       account = {
+        tracker: 'UA-XXXXXX-xx',
+        select: function () {
+          return false;
+        }
+      };
+      spyOn(account, 'select');
+      AnalyticsProvider.setAccount(account);
+    }));
+
+    it('should not run with commands after configuration when select returns false', function () {
+      inject(function (Analytics) {
+        Analytics.log.length = 0; // clear log
+        Analytics.trackPage('/path/to', 'title');
+        expect(Analytics.log.length).toEqual(0);
+        expect(account.select).toHaveBeenCalledWith(['send', 'pageview', { page: '/path/to', title: 'title' }]);
+      });
+    });
+  });
+
   describe('ignoreFirstPageLoad configuration support', function () {
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.ignoreFirstPageLoad(true);

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -140,6 +140,31 @@ describe('universal analytics', function () {
     });
   });
 
+  describe('account custom set commands support', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider
+        .setAccount({
+          tracker: 'UA-XXXXXX-xx',
+          set: {
+            forceSSL: true
+          }
+        })
+        .setHybridMobileSupport(true)
+        .delayScriptTag(true);
+    }));
+
+    it('should set the account object to use forceSSL', function () {
+      inject(function (Analytics) {
+        Analytics.log.length = 0; // clear log
+        Analytics.createAnalyticsScriptTag();
+        expect(Analytics.log[0]).toEqual(['inject', 'https://www.google-analytics.com/analytics.js']);
+        expect(Analytics.log[1]).toEqual(['create', 'UA-XXXXXX-xx', { cookieDomain: 'auto' }]);
+        expect(Analytics.log[2]).toEqual(['set', 'checkProtocolTask', null]);
+        expect(Analytics.log[3]).toEqual(['set', 'forceSSL', true]);
+      });
+    });
+  });
+
   describe('ignoreFirstPageLoad configuration support', function () {
     beforeEach(module(function (AnalyticsProvider) {
       AnalyticsProvider.ignoreFirstPageLoad(true);


### PR DESCRIPTION
Fixes #71, #116
* Support for custom set commands that are run immediately after account object
creation.
* Support for a custom select function on each account object that can disable a tracker by returning false.