### PR TITLE
Add support for UA exception tracking and user opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,15 @@ If set to a truthy value then each account object will disable protocol checking
   AnalyticsProvider.startOffline(true);
 ```
 
+### Disable Analytics / User Opt-out
+```js
+  // Disable analytics data gathering via the user opt-out feature in Google Analytics. More information on this
+  // is available here: https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#optout.
+  AnalyticsProvider.disableAnalytics(true);
+```
+
+**Note:** Using this configuration option requires that you already know the user wants to opt-out before the analytics script is injected on the page. This is somewhat unlikely for most use cases given the nature of a single page application. This module provides a better alternative with `Offline` mode since you can effectively opt the user out of tracking by enabling offline mode at any time during execution.
+
 ### Service Logging
 ```js
   // Log all outbound calls to an in-memory array accessible via ```Analytics.log``` (default is false).
@@ -319,6 +328,7 @@ The following configuration settings are intended to be immutable. While the val
   Analytics.configuration.debugMode;
 
   Analytics.configuration.delayScriptTag;
+  Analytics.configuration.disableAnalytics;
   Analytics.configuration.displayFeatures;
   Analytics.configuration.domainName;
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Proudly brought to you by [@revolunet](http://twitter.com/revolunet), [@deltaeps
  - multiple tracking objects
  - hybrid mobile application support
  - offline mode
+ - analytics.js advanced debugging support
 
 ## Installation
 
@@ -540,6 +541,14 @@ Enhanced e-commerce is only available for universal analytics. Enhanced e-commer
   // example:
   Analytics.addPromo('PROMO_1234', 'Summer Sale', 'summer_banner2', 'banner_slot1');
   Analytics.promoClick('Summer Sale');
+```
+
+### Exception Tracking
+```js
+  Analytics.trackException(description, isFatal);
+
+  // example:
+  Analytics.trackException('Function "foo" is undefined on object "bar"', true);
 ```
 
 ### Online / Offline Mode

--- a/index.js
+++ b/index.js
@@ -985,7 +985,7 @@
          * https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#customs
          * @param name (Required)
          * @param value (Required)
-         * @param trackerName (Not Required)
+         * @param trackerName (Optional)
          * @private
          */
         this._set = function (name, value, trackerName) {
@@ -999,11 +999,22 @@
          * @param timingCategory (Required): A string for categorizing all user timing variables into logical groups(e.g jQuery).
          * @param timingVar (Required): A string to identify the variable being recorded(e.g. JavaScript Load).
          * @param timingValue (Required): The number of milliseconds in elapsed time to report to Google Analytics(e.g. 20).
-         * @param timingLabel (Not Required): A string that can be used to add flexibility in visualizing user timings in the reports(e.g. Google CDN).
+         * @param timingLabel (Optional): A string that can be used to add flexibility in visualizing user timings in the reports(e.g. Google CDN).
          * @private
          */
         this._trackTimings = function (timingCategory, timingVar, timingValue, timingLabel) {
           this._send('timing', timingCategory, timingVar, timingValue, timingLabel);
+        };
+
+        /**
+         * Exception tracking
+         * https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions
+         * @param description (Optional): A description of the exception.
+         * @param isFatal (Optional): true if the exception was fatal, false otherwise.
+         * @private
+         */
+        this._trackException = function (description, isFatal) {
+          this._send('exception', { exDescription: description, exFatal: !!isFatal});
         };
 
         // creates the Google Analytics tracker
@@ -1126,8 +1137,11 @@
           trackTimings: function (timingCategory, timingVar, timingValue, timingLabel) {
             that._trackTimings.apply(that, arguments);
           },
-          trackTransaction: function (transactionId, affiliation, revenue, tax, shipping, coupon, list, step, option){
+          trackTransaction: function (transactionId, affiliation, revenue, tax, shipping, coupon, list, step, option) {
             that._trackTransaction.apply(that, arguments);
+          },
+          trackException: function (description, isFatal) {
+            that._trackException.apply(that, arguments);
           },
           setAction: function (action, obj) {
             that._setAction.apply(that, arguments);

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@
           debugMode = false,
           delayScriptTag = false,
           displayFeatures = false,
+          disableAnalytics = false,
           domainName,
           ecommerce = false,
           enhancedEcommerce = false,
@@ -142,6 +143,11 @@
 
       this.trackUrlParams = function (val) {
         trackUrlParams = !!val;
+        return this;
+      };
+
+      this.disableAnalytics = function (val) {
+        disableAnalytics = !!val;
         return this;
       };
 
@@ -372,6 +378,11 @@
             return;
           }
 
+          if (disableAnalytics === true) {
+            that._log('info', 'Analytics disabled: ' + accounts[0].tracker);
+            $window['ga-disable-' + accounts[0].tracker] = true;
+          }
+
           _gaq('_setAccount', accounts[0].tracker);
           if(domainName) {
             _gaq('_setDomainName', domainName);
@@ -420,6 +431,13 @@
           if (created === true) {
             that._log('warn', 'ga.js or analytics.js script tag already created');
             return;
+          }
+
+          if (disableAnalytics === true) {
+            accounts.forEach(function (trackerObj) {
+              that._log('info', 'Analytics disabled: ' + trackerObj.tracker);
+              $window['ga-disable-' + trackerObj.tracker] = true;
+            });
           }
 
           var document = $document[0];
@@ -1044,6 +1062,7 @@
             currency: currency,
             debugMode: debugMode,
             delayScriptTag: delayScriptTag,
+            disableAnalytics: disableAnalytics,
             displayFeatures: displayFeatures,
             domainName: domainName,
             ecommerce: that._ecommerceEnabled(),

--- a/test/unit/disable-analytics.js
+++ b/test/unit/disable-analytics.js
@@ -1,0 +1,78 @@
+/* global afterEach, before, beforeEach, describe, document, expect, inject, it, module, spyOn */
+'use strict';
+
+describe('disable analytics / user opt-out', function () {
+  beforeEach(module('angular-google-analytics'));
+  beforeEach(module(function (AnalyticsProvider) {
+    AnalyticsProvider
+      .setAccount('UA-XXXXXX-xx')
+      .logAllCalls(true)
+      .enterTestMode();
+  }));
+
+  afterEach(inject(function (Analytics) {
+    Analytics.log.length = 0; // clear log
+  }));
+
+  describe('with universal analytics', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.useAnalytics(true);
+    }));
+
+    it('should be enabled by default', function () {
+      inject(function (Analytics) {
+        expect(Analytics.configuration.disableAnalytics).toBe(false);
+      });
+    });
+
+    describe('when disabled', function () {
+      beforeEach(module(function (AnalyticsProvider) {
+        AnalyticsProvider.disableAnalytics(true);
+      }));
+
+      it('should be disabled', function () {
+        inject(function (Analytics) {
+          expect(Analytics.configuration.disableAnalytics).toBe(true);
+        });
+      });
+
+      it('should log an info message about the account being disabled', function () {
+        inject(function (Analytics, $window) {
+          expect(Analytics.log[0]).toEqual([ 'info', 'Analytics disabled: UA-XXXXXX-xx' ]);
+          expect($window['ga-disable-UA-XXXXXX-xx']).toBe(true);
+        });
+      });
+    });
+  });
+
+  describe('with classic analytics', function () {
+    beforeEach(module(function (AnalyticsProvider) {
+      AnalyticsProvider.useAnalytics(false);
+    }));
+
+    it('should be enabled by default', function () {
+      inject(function (Analytics) {
+        expect(Analytics.configuration.disableAnalytics).toBe(false);
+      });
+    });
+
+    describe('when disabled', function () {
+      beforeEach(module(function (AnalyticsProvider) {
+        AnalyticsProvider.disableAnalytics(true);
+      }));
+
+      it('should be disabled', function () {
+        inject(function (Analytics) {
+          expect(Analytics.configuration.disableAnalytics).toBe(true);
+        });
+      });
+
+      it('should log an info message about the account being disabled', function () {
+        inject(function (Analytics, $window) {
+          expect(Analytics.log[0]).toEqual([ 'info', 'Analytics disabled: UA-XXXXXX-xx' ]);
+          expect($window['ga-disable-UA-XXXXXX-xx']).toBe(true);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/track-exception.js
+++ b/test/unit/track-exception.js
@@ -1,0 +1,39 @@
+/* global afterEach, before, beforeEach, describe, document, expect, inject, it, module, spyOn */
+'use strict';
+
+describe('universal analytics exception tracking', function () {
+  beforeEach(module('angular-google-analytics'));
+  beforeEach(module(function (AnalyticsProvider) {
+    AnalyticsProvider
+      .setAccount('UA-XXXXXX-xx')
+      .useAnalytics(true)
+      .logAllCalls(true)
+      .enterTestMode();
+  }));
+
+  afterEach(inject(function (Analytics) {
+    Analytics.log.length = 0; // clear log
+  }));
+
+  it('should have a trackException method', function () {
+    inject(function (Analytics) {
+      expect(typeof Analytics.trackException === 'function').toBe(true);
+    });
+  });
+
+  it('should allow for tracking an exception with no parameters provided', function () {
+    inject(function (Analytics) {
+      Analytics.log.length = 0; // clear log
+      Analytics.trackException();
+      expect(Analytics.log[0]).toEqual(['send', 'exception', { exDescription: undefined, exFatal: false }]);
+    });
+  });
+
+  it('should allow for tracking an exception with all parameters provided', function () {
+    inject(function (Analytics) {
+      Analytics.log.length = 0; // clear log
+      Analytics.trackException('Something fatal happened!', true);
+      expect(Analytics.log[0]).toEqual(['send', 'exception', { exDescription: 'Something fatal happened!', exFatal: true }]);
+    });
+  });
+});

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -529,8 +529,7 @@ describe('universal analytics', function () {
         Analytics.productClick('dummy list');
         expect(Analytics.log.length).toBe(3);
         expect(Analytics.log[0][0]).toBe('ec:addProduct');
-        expect(Analytics.log[1][0]).toBe('ec:setAction');
-        expect(Analytics.log[1][1]).toBe('click');
+        expect(Analytics.log[1]).toEqual([ 'ec:setAction', 'click', { list: 'dummy list' } ]);
         expect(Analytics.log[2]).toEqual([ 'send', 'event', 'UX', 'click', 'dummy list', undefined, {} ]);
       });
     });
@@ -542,8 +541,7 @@ describe('universal analytics', function () {
         Analytics.trackDetail();
         expect(Analytics.log.length).toBe(3);
         expect(Analytics.log[0][0]).toBe('ec:addProduct');
-        expect(Analytics.log[1][0]).toBe('ec:setAction');
-        expect(Analytics.log[1][1]).toBe('detail');
+        expect(Analytics.log[1]).toEqual([ 'ec:setAction', 'detail', undefined ]);
         expect(Analytics.log[2]).toEqual(['send', 'pageview']);
       });
     });
@@ -555,8 +553,7 @@ describe('universal analytics', function () {
         Analytics.trackCart('add');
         expect(Analytics.log.length).toBe(3);
         expect(Analytics.log[0][0]).toBe('ec:addProduct');
-        expect(Analytics.log[1][0]).toBe('ec:setAction');
-        expect(Analytics.log[1][1]).toBe('add');
+        expect(Analytics.log[1]).toEqual([ 'ec:setAction', 'add', { list: undefined } ]);
         expect(Analytics.log[2]).toEqual([ 'send', 'event', 'UX', 'click', 'add to cart', undefined, {} ]);
       });
     });
@@ -568,7 +565,7 @@ describe('universal analytics', function () {
         Analytics.trackCart('add', 'product-list');
         expect(Analytics.log.length).toBe(3);
         expect(Analytics.log[0][0]).toBe('ec:addProduct');
-        expect(Analytics.log[1]).toEqual([ 'ec:setAction', 'add', {list: 'product-list'} ]);
+        expect(Analytics.log[1]).toEqual([ 'ec:setAction', 'add', { list: 'product-list' } ]);
         expect(Analytics.log[2]).toEqual([ 'send', 'event', 'UX', 'click', 'add to cart', undefined, {} ]);
       });
     });
@@ -580,8 +577,7 @@ describe('universal analytics', function () {
         Analytics.trackCart('remove');
         expect(Analytics.log.length).toBe(3);
         expect(Analytics.log[0][0]).toBe('ec:addProduct');
-        expect(Analytics.log[1][0]).toBe('ec:setAction');
-        expect(Analytics.log[1][1]).toBe('remove');
+        expect(Analytics.log[1]).toEqual([ 'ec:setAction', 'remove', { list: undefined } ]);
         expect(Analytics.log[2]).toEqual([ 'send', 'event', 'UX', 'click', 'remove from cart', undefined, {} ]);
       });
     });


### PR DESCRIPTION
Fixes #98, #130

* Added support for user opt-out as defined by Google Analytics via a disableAnalytics configuration option.
* Universal Analytics supports exception tracking via a special form of the send command. Added support to the angular library to make this more intuitive for developers.