### PR TITLE
Support for $routeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,26 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
   // RegEx to scrub location before sending to analytics.
   // Internally replaces all matching segments with an empty string.
   AnalyticsProvider.setRemoveRegExp(/\/\d+?$/);
+  
+  // Activate reading custom tracking urls from $routeProvider config (default is false)
+  // This is more flexibale than using RegExp and easier to maintain for multiple parameters
+  AnalyticsProvider.readFromRoute();
+  // Add custom routes to the $routeProvider like this
+  $routeProvider
+    .when('/sessions', {
+      templateUrl: 'list.html',
+      controller: 'ListController'
+    })
+    .when('/session/:id',{
+      templateUrl : 'master.html',
+      controller: 'MasterController',
+      pageTrack: '/session'
+    })
+    .when('/member/:sessionId/:memberId', {
+      templateUrl : 'member.html',
+      controller: 'CardController',
+      pageTrack: '/member',
+    });
 ```
 
 ### Set Domain Name

--- a/index.js
+++ b/index.js
@@ -240,12 +240,12 @@
           Object.keys(routes).forEach(function (key) {
             var route = routes[key];
             // Check if url matches this route
-          	if (!("regexp" in route) || !route.regexp.test(url)) {
+            if (!("regexp" in route) || !route.regexp.test(url)) {
               return;
             }
             if ("pageTrack" in route) {
               trackUrl = route.pageTrack;
-          	}
+            }
           });
           // Check if we found something in routes
           if (trackUrl) {
@@ -253,7 +253,7 @@
           }
            
           // Otherwise go the old way
- 		      url = trackUrlParams ? $location.url() : $location.path(); 
+          url = trackUrlParams ? $location.url() : $location.path(); 
           return removeRegExp ? url.replace(removeRegExp, '') : url;
         };
 

--- a/index.js
+++ b/index.js
@@ -33,13 +33,13 @@
           hybridMobileSupport = false,
           offlineMode = false,
           pageEvent = '$routeChangeSuccess',
+          readFromRoute = false,
           removeRegExp,
           testMode = false,
           traceDebuggingMode = false,
           trackPrefix = '',
           trackRoutes = true,
-          trackUrlParams = false,
-          readFromRoute = false;
+          trackUrlParams = false;
 
       this.log = [];
       this.offlineQueue = [];
@@ -188,8 +188,8 @@
       
       // Enable reading page url from route object
       this.readFromRoute = function() {
-      	readFromRoute = true;
-      	return this;
+        readFromRoute = true;
+        return this;
       };
 
       /**
@@ -223,7 +223,16 @@
           return isPropertyDefined('name', config) ? (config.name + '.' + commandName) : commandName;
         };
         
-        var routes = readFromRoute ? $injector.get('$route').routes : { };
+        // Try to read route configuration and log warning if not possible
+        var routes = {};
+        if (readFromRoute) {
+          var $route = $injector.get('$route');
+          if (!$route) {
+            $log.warn('$route service is not available. Make sure you have included ng-route in your application dependencies.');
+          } else {
+            routes = $route.routes;
+          }
+        }
         var getUrl = function () {
           // Using ngRoute provided tracking urls
           var url = $location.url();
@@ -231,17 +240,20 @@
           Object.keys(routes).forEach(function (key) {
             var route = routes[key];
             // Check if url matches this route
-          	if (!("regexp" in route) || !route.regexp.test(url))
+          	if (!("regexp" in route) || !route.regexp.test(url)) {
               return;
-          	if ("pageTrack" in route)
-          	  trackUrl = route.pageTrack;
+            }
+            if ("pageTrack" in route) {
+              trackUrl = route.pageTrack;
+          	}
           });
           // Check if we found something in routes
-          if(trackUrl)
+          if (trackUrl) {
             return trackUrl;
+          }
            
           // Otherwise go the old way
- 		  url = trackUrlParams ? $location.url() : $location.path(); 
+ 		      url = trackUrlParams ? $location.url() : $location.path(); 
           return removeRegExp ? url.replace(removeRegExp, '') : url;
         };
 
@@ -1110,6 +1122,7 @@
             ignoreFirstPageLoad: ignoreFirstPageLoad,
             logAllCalls: logAllCalls,
             pageEvent: pageEvent,
+            readFromRoute = readFromRoute,
             removeRegExp: removeRegExp,
             testMode: testMode,
             traceDebuggingMode: traceDebuggingMode,

--- a/index.js
+++ b/index.js
@@ -240,10 +240,10 @@
           Object.keys(routes).forEach(function (key) {
             var route = routes[key];
             // Check if url matches this route
-            if (!("regexp" in route) || !route.regexp.test(url)) {
+            if (!('regexp' in route) || !route.regexp.test(url)) {
               return;
             }
-            if ("pageTrack" in route) {
+            if ('pageTrack' in route) {
               trackUrl = route.pageTrack;
             }
           });
@@ -1122,7 +1122,7 @@
             ignoreFirstPageLoad: ignoreFirstPageLoad,
             logAllCalls: logAllCalls,
             pageEvent: pageEvent,
-            readFromRoute = readFromRoute,
+            readFromRoute: readFromRoute,
             removeRegExp: removeRegExp,
             testMode: testMode,
             traceDebuggingMode: traceDebuggingMode,

--- a/index.js
+++ b/index.js
@@ -1,11 +1,3 @@
-/**
- * Angular Google Analytics - Easy tracking for your AngularJS application
- * @version v1.1.6 - 2016-01-27
- * @link http://github.com/revolunet/angular-google-analytics
- * @author Julien Bouquillon <julien@revolunet.com> (https://github.com/revolunet)
- * @contributors Julien Bouquillon (https://github.com/revolunet),Justin Saunders (https://github.com/justinsa),Chris Esplin (https://github.com/deltaepsilon),Adam Misiorny (https://github.com/adam187)
- * @license MIT License, http://www.opensource.org/licenses/MIT
- */
 /* globals define */
 (function (root, factory) {
   'use strict';


### PR DESCRIPTION
I forked the project to add support for defining the tracking URL in the $routeProvider config because I needed it in a project. Maybe you can use this as well.

You can see and debug it in production use at [Scrumpoker Online](http://scrumpoker.online).