### PR TITLE
PageTracking configuration in $route

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
     })
     .otherwise({
       templateUrl: '404.html',
-      dontTrack: true
+      doNotTrack: true
     });
 ```
 

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
   // This is more flexible than using RegExp and easier to maintain for multiple parameters.
   // It also reduces tracked pages to routes defined in the $routeProvider and therefor reduces
   // bounce rate created by redirects. You can also exclude certain routes from tracking by
-  // adding 'dontTrack' property
+  // adding 'doNotTrack' property
   AnalyticsProvider.readFromRoute(true);
   // Add custom routes to the $routeProvider like this
   $routeProvider

--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
       pageTrack: '/member',
     })
     .otherwise({
-      	templateUrl: '404.html',
-      	dontTrack: true
+      templateUrl: '404.html',
+      dontTrack: true
     });
 ```
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
   AnalyticsProvider.setRemoveRegExp(/\/\d+?$/);
   
   // Activate reading custom tracking urls from $routeProvider config (default is false)
-  // This is more flexible than using RegExp and easier to maintain for multiple parameters
+  // This is more flexible than using RegExp and easier to maintain for multiple parameters.
+  // It also reduces tracked pages to routes defined in the $routeProvider and therefor reduces
+  // bounce rate created by redirects.
   AnalyticsProvider.readFromRoute(true);
   // Add custom routes to the $routeProvider like this
   $routeProvider

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
   // Activate reading custom tracking urls from $routeProvider config (default is false)
   // This is more flexible than using RegExp and easier to maintain for multiple parameters.
   // It also reduces tracked pages to routes defined in the $routeProvider and therefor reduces
-  // bounce rate created by redirects.
+  // bounce rate created by redirects. You can also exclude certain routes from tracking by
+  // adding 'dontTrack' property
   AnalyticsProvider.readFromRoute(true);
   // Add custom routes to the $routeProvider like this
   $routeProvider
@@ -240,6 +241,10 @@ Set `trackEcommerce: false` for an account object that is not tracking e-commerc
       templateUrl : 'member.html',
       controller: 'CardController',
       pageTrack: '/member',
+    })
+    .otherwise({
+      	templateUrl: '404.html',
+      	dontTrack: true
     });
 ```
 

--- a/index.js
+++ b/index.js
@@ -232,6 +232,8 @@
             $route = $injector.get('$route');
           }
         }
+
+        // Get url for current page 
         var getUrl = function () {
           // Using ngRoute provided tracking urls
           if (readFromRoute && $route.current && ('pageTrack' in $route.current)) {
@@ -1082,6 +1084,12 @@
         // activates page tracking
         if (trackRoutes) {
           $rootScope.$on(pageEvent, function () {
+            // Avoid tracking routes not defined as a page
+            if (readFromRoute && !($route.current && $route.current.templateUrl)) {
+              return;
+            }
+            
+            // Track the page
             that._trackPage();
           });
         }

--- a/index.js
+++ b/index.js
@@ -1084,12 +1084,15 @@
         // activates page tracking
         if (trackRoutes) {
           $rootScope.$on(pageEvent, function () {
-            // Avoid tracking routes not defined as a page or which explicitly deactivate tracking
-            if (readFromRoute && !($route.current && $route.current.templateUrl && !$route.current.dontTrack)) {
-              return;
+            // Apply $route based filtering if configured
+            if (readFromRoute) {
+              // Avoid tracking undefined routes, routes without template (e.g. redirect routes)
+              // and those explicitly marked as 'do not track'
+              if (!$route.current || !$route.current.templateUrl || $route.current.doNotTrack) {
+                return;
+              }
             }
             
-            // Track the page
             that._trackPage();
           });
         }

--- a/index.js
+++ b/index.js
@@ -1084,8 +1084,8 @@
         // activates page tracking
         if (trackRoutes) {
           $rootScope.$on(pageEvent, function () {
-            // Avoid tracking routes not defined as a page
-            if (readFromRoute && !($route.current && $route.current.templateUrl)) {
+            // Avoid tracking routes not defined as a page or which explicitly deactivate tracking
+            if (readFromRoute && !($route.current && $route.current.templateUrl && !$route.current.dontTrack)) {
               return;
             }
             

--- a/test/unit/route-reading.js
+++ b/test/unit/route-reading.js
@@ -99,7 +99,7 @@ describe('Reading from $route service', function() {
       });
     });
     
-    it('should not track routes with \'dontTrack\' attribute', function() {
+    it('should not track routes with \'doNotTrack\' attribute', function() {
       inject(function(Analytics, $window, $rootScope, $route) {
         $route.current = { templateUrl: '/myTemplate', doNotTrack: true };
         $window._gaq.length = 0; // clear queue
@@ -144,7 +144,7 @@ describe('Reading from $route service', function() {
       });
     });
     
-    it('should not track routes with \'dontTrack\' attribute', function() {
+    it('should not track routes with \'doNotTrack\' attribute', function() {
       inject(function(Analytics, $rootScope, $route) {
         $route.current = { templateUrl: '/myTemplate', doNotTrack: true };
         Analytics.log.length = 0; // clear queue

--- a/test/unit/route-reading.js
+++ b/test/unit/route-reading.js
@@ -37,13 +37,11 @@ describe('Reading from $route service', function() {
   
   describe('after setting readFromRoute', function() {
     beforeEach(module(function(AnalyticsProvider, $provide){
-      AnalyticsProvider.readFromRoute(true)
-              // Use classic analytics because have no idea how to track events for the universal one :D
-                       .useAnalytics(false);
+      AnalyticsProvider.readFromRoute(true);
       $provide.service('$route', function () {
         this.routes = {
           someroute: { pageTrack: '/some' },
-          otherroute: { },
+          otherroute: { }
         };
       });
     }));
@@ -74,7 +72,15 @@ describe('Reading from $route service', function() {
         $location.url('/undefinedroute');
         expect(Analytics.getUrl()).toBe('/undefinedroute');
       });
-    });
+    });  
+  });
+  
+  describe('after setting readFromRoute for classic analytics', function() {
+    beforeEach(module(function(AnalyticsProvider, $provide){
+      AnalyticsProvider.readFromRoute(true)
+                       .useAnalytics(false);
+      $provide.service('$route', function () { });
+    }));
     
     it('should not track undefined routes', function() {
       inject(function(Analytics, $window, $rootScope) {
@@ -95,7 +101,7 @@ describe('Reading from $route service', function() {
     
     it('should not track routes with \'dontTrack\' attribute', function() {
       inject(function(Analytics, $window, $rootScope, $route) {
-        $route.current = { templateUrl: '/myTemplate', dontTrack: true };
+        $route.current = { templateUrl: '/myTemplate', doNotTrack: true };
         $window._gaq.length = 0; // clear queue
         $rootScope.$broadcast('$routeChangeSuccess');
         expect($window._gaq.length).toBe(0);
@@ -110,6 +116,50 @@ describe('Reading from $route service', function() {
         expect($window._gaq.length).toBe(2);
         expect($window._gaq[0]).toEqual(['_set', 'title', '']);
         expect($window._gaq[1]).toEqual(['_trackPageview', '/myTrack']);
+      });
+    });
+  });
+  
+  describe('after setting readFromRoute for universal analytics', function() {
+    beforeEach(module(function(AnalyticsProvider, $provide){
+      AnalyticsProvider.readFromRoute(true)
+                       .useAnalytics(true);
+      $provide.service('$route', function () { });
+    }));
+    
+    it('should not track undefined routes', function() {
+      inject(function(Analytics, $rootScope) {
+        Analytics.log.length = 0; // clear queue
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect(Analytics.log.length).toBe(0);
+      });
+    });
+    
+    it('should not track routes without template', function() {
+      inject(function(Analytics, $rootScope, $route) {
+        $route.current = { };
+        Analytics.log.length = 0; // clear queue
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect(Analytics.log.length).toBe(0);
+      });
+    });
+    
+    it('should not track routes with \'dontTrack\' attribute', function() {
+      inject(function(Analytics, $rootScope, $route) {
+        $route.current = { templateUrl: '/myTemplate', doNotTrack: true };
+        Analytics.log.length = 0; // clear queue
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect(Analytics.log.length).toBe(0);
+      });
+    });
+    
+    it('should track routes with a defined template (no redirect)', function() {
+      inject(function(Analytics, $window, $rootScope, $route) {
+        $route.current = { templateUrl: '/myTemplate', pageTrack: '/myTrack' };
+        Analytics.log.length = 0; // clear queue
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect(Analytics.log.length).toBe(1);
+        expect(Analytics.log[0]).toEqual(['send', 'pageview', { page: '/myTrack', title: '' }]);
       });
     });
   });

--- a/test/unit/route-reading.js
+++ b/test/unit/route-reading.js
@@ -93,6 +93,15 @@ describe('Reading from $route service', function() {
       });
     });
     
+    it('should not track routes with \'dontTrack\' attribute', function() {
+      inject(function(Analytics, $window, $rootScope, $route) {
+        $route.current = { templateUrl: '/myTemplate', dontTrack: true };
+        $window._gaq.length = 0; // clear queue
+        $rootScope.$broadcast('$routeChangeSuccess');
+        expect($window._gaq.length).toBe(0);
+      });
+    });
+    
     it('should track routes with a defined template (no redirect)', function() {
       inject(function(Analytics, $window, $rootScope, $route) {
         $route.current = { templateUrl: '/myTemplate', pageTrack: '/myTrack' };


### PR DESCRIPTION
This builds upon PR #142 and fixes bug report #76 for applications that use ngRoute. It reduces tracked pages to those routes that do define a templateUrl (routes with a page) and skips routes marked with ``dontTrack: true`` property.

I allready included unit tests to verify correct behahior.