### PR TITLE
Separate script injection and tracker setup methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,9 +266,7 @@ to the official [angular ngRoute documentation](https://docs.angularjs.org/api/n
 ```
 **Note:** only a single experiment can be defined.
 
-### Support Hybrid Mobile Applications
-This property is defined for universal analytics only and is false by default.
-
+### Support Hybrid Mobile Applications (universal analytics only)
 ```js
   // Set hybrid mobile application support
   AnalyticsProvider.setHybridMobileSupport(true);
@@ -276,13 +274,14 @@ This property is defined for universal analytics only and is false by default.
 
 If set to a truthy value then each account object will disable protocol checking and all injected scripts will use the HTTPS protocol.
 
-### Delay Script Tag Insertion
+### Delay Script Tag Insertion and Tracker Setup
 ```js
-  // Must manually call create script tag method in order to insert and configure Google Analytics:
-  //   Classic analytics:   Analytics.createScriptTag();
-  //   Universal analytics: Analytics.createAnalyticsScriptTag();
+  // Must manually call registerScriptTags method in order to insert the Google Analytics scripts on the page.
+  //   Analytics.registerScriptTags();
+  // Must manually call registerTrackers method in order to setup the trackers with Google Analytics.
+  //   Analytics.registerTrackers();
   // Helpful when needing to do advanced configuration or user opt-out and wanting explicit control
-  // over when the Google Analytics script gets injected.
+  // over when the Google Analytics scripts get injected or tracker setup happens.
   AnalyticsProvider.delayScriptTag(true);
 ```
 
@@ -380,19 +379,6 @@ The following configuration settings are intended to be immutable. While the val
   Analytics.configuration.trackUrlParams;
 ```
 
-### Get or Set Cookie Configuration
-**NOTE:** These methods are being **deprecated**. Use the `fields` property on the account object instead.
-
-```js
-  // Get the global cookie config.
-  Analytics.getCookieConfig();
-
-  // Set the global cookie config.
-  // Impacts all future calls for classic analytics (ga.js).
-  Analytics.setCookieConfig();
-```
-**Note:** Changing the cookie configuration after the AnalyticsProvider configuration does not update the individual account objects used by universal analytics (analytics.js). If you want to change the account objects used by universal analytics those can be accessed through `Analytics.configuration.accounts`, but such modification to the accounts object is unsupported.
-
 ### Get URL
 ```js
   // Returns the current URL that would be sent if a `trackPage` call was made.
@@ -400,14 +386,14 @@ The following configuration settings are intended to be immutable. While the val
   Analytics.getUrl();
 ```
 
-### Manual Script Tag Injection
-If `delayScriptTag(true)` was set during configuration then manual script tag injection is required. Otherwise, the script tag will be automatically injected and configured when the service is instantiated.
+### Manual Script Tag Injection and Tracker Setup
+If `delayScriptTag(true)` was set during configuration then manual script tag injection and tracker setup is required. Otherwise, the script tag and trackers will be automatically injected and configured when the service is instantiated.
 ```js
-  // Manually create classic analytics (ga.js) script tag
-  Analytics.createScriptTag();
+  // Manually create either classic analytics (ga.js) or universal analytics (analytics.js) script tags
+  Analytics.registerScriptTags();
 
-  // Manually create universal analytics (analytics.js) script tag
-  Analytics.createAnalyticsScriptTag();
+  // Manually setup the tracker object(s)
+  Analytics.registerTrackers();
 ```
 
 ### Advanced Settings / Custom Dimensions

--- a/index.js
+++ b/index.js
@@ -195,10 +195,10 @@
       /**
        * Public Service
        */
-      this.$get = ['$document', // To read title 
-                   '$location', // 
+      this.$get = ['$document', // To read page title 
+                   '$location', //
                    '$log',      //
-                   '$rootScope',// 
+                   '$rootScope',//
                    '$window',   //
                    '$injector', // To access ngRoute module without declaring a fixed dependency
                    function ($document, $location, $log, $rootScope, $window, $injector) {
@@ -393,73 +393,25 @@
           }
         };
 
+        /* DEPRECATED */
         this._createScriptTag = function () {
-          if (!accounts || accounts.length < 1) {
-            that._log('warn', 'No account id set to create script tag');
-            return;
-          }
-          if (accounts.length > 1) {
-            that._log('warn', 'Multiple trackers are not supported with ga.js. Using first tracker only');
-            accounts = accounts.slice(0, 1);
-          }
-
-          if (created === true) {
-            that._log('warn', 'ga.js or analytics.js script tag already created');
-            return;
-          }
-
-          if (disableAnalytics === true) {
-            that._log('info', 'Analytics disabled: ' + accounts[0].tracker);
-            $window['ga-disable-' + accounts[0].tracker] = true;
-          }
-
-          _gaq('_setAccount', accounts[0].tracker);
-          if(domainName) {
-            _gaq('_setDomainName', domainName);
-          }
-          if (enhancedLinkAttribution) {
-            _gaq('_require', 'inpage_linkid', '//www.google-analytics.com/plugins/ga/inpage_linkid.js');
-          }
-          if (trackRoutes && !ignoreFirstPageLoad) {
-            if (removeRegExp) {
-              _gaq('_trackPageview', getUrl());
-            } else {
-              _gaq('_trackPageview');
-            }
-          }
-
-          var document = $document[0];
-          var scriptSource;
-          if (displayFeatures === true) {
-            scriptSource = ('https:' === document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
-          } else {
-            scriptSource = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-          }
-
-          if (testMode !== true) {
-            // If not in test mode inject the Google Analytics tag
-            (function () {
-              var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-              ga.src = scriptSource;
-              var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-            })();
-          } else {
-            // Log the source location for validation
-            that._log('inject', scriptSource);
-          }
-
-          created = true;
-          return true;
+          that._registerScriptTags();
+          that._registerTrackers();
         };
 
+        /* DEPRECATED */
         this._createAnalyticsScriptTag = function () {
-          if (!accounts) {
-            that._log('warn', 'No account id set to create analytics script tag');
-            return;
-          }
+          that._registerScriptTags();
+          that._registerTrackers();
+        };
+
+        this._registerScriptTags = function () {
+          var document = $document[0],
+              protocol = '',
+              scriptSource;
 
           if (created === true) {
-            that._log('warn', 'ga.js or analytics.js script tag already created');
+            that._log('warn', 'Script tags already created');
             return;
           }
 
@@ -470,113 +422,174 @@
             });
           }
 
-          var document = $document[0];
-          var protocol = hybridMobileSupport === true ? 'https:' : '';
-          var scriptSource = protocol + '//www.google-analytics.com/' + (debugMode ? 'analytics_debug.js' : 'analytics.js');
-          if (testMode !== true) {
-            // If not in test mode inject the Google Analytics tag
-            (function (i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function (){
-              (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
-              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
-            })(window,document,'script',scriptSource,'ga');
+          //
+          // Universal Analytics
+          //
+          if (analyticsJS === true) {
+            protocol = hybridMobileSupport === true ? 'https:' : '';
+            scriptSource = protocol + '//www.google-analytics.com/' + (debugMode ? 'analytics_debug.js' : 'analytics.js');
+            if (testMode !== true) {
+              // If not in test mode inject the Google Analytics tag
+              (function (i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function (){
+                (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
+                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
+              })(window,document,'script',scriptSource,'ga');
+            } else {
+              if (typeof $window.ga !== 'function') {
+                // In test mode create a ga function if none exists that is a noop sink.
+                $window.ga = function () {};
+              }
+              // Log script injection.
+              that._log('inject', scriptSource);
+            }
+
+            if (traceDebuggingMode) {
+              $window.ga_debug = { trace: true };
+            }
+
+            if (experimentId) {
+              var expScript = document.createElement('script'),
+                  s = document.getElementsByTagName('script')[0];
+              expScript.src = protocol + '//www.google-analytics.com/cx/api.js?experiment=' + experimentId;
+              s.parentNode.insertBefore(expScript, s);
+            }
+          //
+          // Classic Analytics
+          //
           } else {
-            if (typeof $window.ga !== 'function') {
-              // In test mode create a ga function if none exists that is a noop sink.
-              $window.ga = function () {};
-            }
-            // Log script injection.
-            that._log('inject', scriptSource);
-          }
-
-          if (traceDebuggingMode) {
-            $window.ga_debug = { trace: true };
-          }
-
-          accounts.forEach(function (trackerObj) {
-            trackerObj.crossDomainLinker = isPropertyDefined('crossDomainLinker', trackerObj) ? trackerObj.crossDomainLinker : crossDomainLinker;
-            trackerObj.crossLinkDomains = isPropertyDefined('crossLinkDomains', trackerObj) ? trackerObj.crossLinkDomains : crossLinkDomains;
-            trackerObj.displayFeatures = isPropertyDefined('displayFeatures', trackerObj) ? trackerObj.displayFeatures : displayFeatures;
-            trackerObj.enhancedLinkAttribution = isPropertyDefined('enhancedLinkAttribution', trackerObj) ? trackerObj.enhancedLinkAttribution : enhancedLinkAttribution;
-            trackerObj.set = isPropertyDefined('set', trackerObj) ? trackerObj.set : {};
-            trackerObj.trackEcommerce = isPropertyDefined('trackEcommerce', trackerObj) ? trackerObj.trackEcommerce : ecommerce;
-            trackerObj.trackEvent = isPropertyDefined('trackEvent', trackerObj) ? trackerObj.trackEvent : false;
-
-            // Logic to choose the account fields to be used.
-            // cookieConfig is being deprecated for a tracker specific property: fields.
-            var fields = {};
-            if (isPropertyDefined('fields', trackerObj)) {
-              fields = trackerObj.fields;
-            } else if (isPropertyDefined('cookieConfig', trackerObj)) {
-              if (angular.isString(trackerObj.cookieConfig)) {
-                fields.cookieDomain = trackerObj.cookieConfig;
-              } else {
-                fields = trackerObj.cookieConfig;
-              }
-            } else if (angular.isString(cookieConfig)) {
-              fields.cookieDomain = cookieConfig;
-            } else if (cookieConfig) {
-              fields = cookieConfig;
-            }
-            if (trackerObj.crossDomainLinker === true) {
-              fields.allowLinker = true;
-            }
-            if (isPropertyDefined('name', trackerObj)) {
-              fields.name = trackerObj.name;
-            }
-            trackerObj.fields = fields;
-
-            _ga('create', trackerObj.tracker, trackerObj.fields);
-
-            // Hybrid mobile application support
-            // https://developers.google.com/analytics/devguides/collection/analyticsjs/tasks
-            if (hybridMobileSupport === true) {
-              _ga(generateCommandName('set', trackerObj), 'checkProtocolTask', null);
+            scriptSource = ('https:' === document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            if (displayFeatures === true) {
+              scriptSource = '//stats.g.doubleclick.net/dc.js';
             }
 
-            // Send all custom set commands from the trackerObj.set property
-            for (var key in trackerObj.set) {
-              if (trackerObj.set.hasOwnProperty(key)) {
-                _ga(generateCommandName('set', trackerObj), key, trackerObj.set[key]);
-              }
+            if (testMode !== true) {
+              // If not in test mode inject the Google Analytics tag
+              (function () {
+                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+                ga.src = scriptSource;
+                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+              })();
+            } else {
+              // Log the source location for validation
+              that._log('inject', scriptSource);
             }
-
-            if (trackerObj.crossDomainLinker === true) {
-              _ga(generateCommandName('require', trackerObj), 'linker');
-              if (angular.isDefined(trackerObj.crossLinkDomains)) {
-                _ga(generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
-              }
-            }
-
-            if (trackerObj.displayFeatures) {
-              _ga(generateCommandName('require', trackerObj), 'displayfeatures');
-            }
-
-            if (trackerObj.trackEcommerce) {
-              if (!enhancedEcommerce) {
-                _ga(generateCommandName('require', trackerObj), 'ecommerce');
-              } else {
-                _ga(generateCommandName('require', trackerObj), 'ec');
-                _ga(generateCommandName('set', trackerObj), '&cu', currency);
-              }
-            }
-
-            if (trackerObj.enhancedLinkAttribution) {
-              _ga(generateCommandName('require', trackerObj), 'linkid');
-            }
-
-            if (trackRoutes && !ignoreFirstPageLoad) {
-              _ga(generateCommandName('send', trackerObj), 'pageview', trackPrefix + getUrl());
-            }
-          });
-
-          if (experimentId) {
-            var expScript = document.createElement('script'),
-                s = document.getElementsByTagName('script')[0];
-            expScript.src = protocol + '//www.google-analytics.com/cx/api.js?experiment=' + experimentId;
-            s.parentNode.insertBefore(expScript, s);
           }
 
           created = true;
+          return true;
+        };
+
+        this._registerTrackers = function () {
+          if (!accounts || accounts.length < 1) {
+            that._log('warn', 'No accounts to register');
+            return;
+          }
+
+          //
+          // Universal Analytics
+          //
+          if (analyticsJS === true) {
+            accounts.forEach(function (trackerObj) {
+              trackerObj.crossDomainLinker = isPropertyDefined('crossDomainLinker', trackerObj) ? trackerObj.crossDomainLinker : crossDomainLinker;
+              trackerObj.crossLinkDomains = isPropertyDefined('crossLinkDomains', trackerObj) ? trackerObj.crossLinkDomains : crossLinkDomains;
+              trackerObj.displayFeatures = isPropertyDefined('displayFeatures', trackerObj) ? trackerObj.displayFeatures : displayFeatures;
+              trackerObj.enhancedLinkAttribution = isPropertyDefined('enhancedLinkAttribution', trackerObj) ? trackerObj.enhancedLinkAttribution : enhancedLinkAttribution;
+              trackerObj.set = isPropertyDefined('set', trackerObj) ? trackerObj.set : {};
+              trackerObj.trackEcommerce = isPropertyDefined('trackEcommerce', trackerObj) ? trackerObj.trackEcommerce : ecommerce;
+              trackerObj.trackEvent = isPropertyDefined('trackEvent', trackerObj) ? trackerObj.trackEvent : false;
+
+              // Logic to choose the account fields to be used.
+              // cookieConfig is being deprecated for a tracker specific property: fields.
+              var fields = {};
+              if (isPropertyDefined('fields', trackerObj)) {
+                fields = trackerObj.fields;
+              } else if (isPropertyDefined('cookieConfig', trackerObj)) {
+                if (angular.isString(trackerObj.cookieConfig)) {
+                  fields.cookieDomain = trackerObj.cookieConfig;
+                } else {
+                  fields = trackerObj.cookieConfig;
+                }
+              } else if (angular.isString(cookieConfig)) {
+                fields.cookieDomain = cookieConfig;
+              } else if (cookieConfig) {
+                fields = cookieConfig;
+              }
+              if (trackerObj.crossDomainLinker === true) {
+                fields.allowLinker = true;
+              }
+              if (isPropertyDefined('name', trackerObj)) {
+                fields.name = trackerObj.name;
+              }
+              trackerObj.fields = fields;
+
+              _ga('create', trackerObj.tracker, trackerObj.fields);
+
+              // Hybrid mobile application support
+              // https://developers.google.com/analytics/devguides/collection/analyticsjs/tasks
+              if (hybridMobileSupport === true) {
+                _ga(generateCommandName('set', trackerObj), 'checkProtocolTask', null);
+              }
+
+              // Send all custom set commands from the trackerObj.set property
+              for (var key in trackerObj.set) {
+                if (trackerObj.set.hasOwnProperty(key)) {
+                  _ga(generateCommandName('set', trackerObj), key, trackerObj.set[key]);
+                }
+              }
+
+              if (trackerObj.crossDomainLinker === true) {
+                _ga(generateCommandName('require', trackerObj), 'linker');
+                if (angular.isDefined(trackerObj.crossLinkDomains)) {
+                  _ga(generateCommandName('linker:autoLink', trackerObj), trackerObj.crossLinkDomains);
+                }
+              }
+
+              if (trackerObj.displayFeatures) {
+                _ga(generateCommandName('require', trackerObj), 'displayfeatures');
+              }
+
+              if (trackerObj.trackEcommerce) {
+                if (!enhancedEcommerce) {
+                  _ga(generateCommandName('require', trackerObj), 'ecommerce');
+                } else {
+                  _ga(generateCommandName('require', trackerObj), 'ec');
+                  _ga(generateCommandName('set', trackerObj), '&cu', currency);
+                }
+              }
+
+              if (trackerObj.enhancedLinkAttribution) {
+                _ga(generateCommandName('require', trackerObj), 'linkid');
+              }
+
+              if (trackRoutes && !ignoreFirstPageLoad) {
+                _ga(generateCommandName('send', trackerObj), 'pageview', trackPrefix + getUrl());
+              }
+            });
+          //
+          // Classic Analytics
+          //
+          } else {
+            if (accounts.length > 1) {
+              that._log('warn', 'Multiple trackers are not supported with ga.js. Using first tracker only');
+              accounts = accounts.slice(0, 1);
+            }
+
+            _gaq('_setAccount', accounts[0].tracker);
+            if(domainName) {
+              _gaq('_setDomainName', domainName);
+            }
+            if (enhancedLinkAttribution) {
+              _gaq('_require', 'inpage_linkid', '//www.google-analytics.com/plugins/ga/inpage_linkid.js');
+            }
+            if (trackRoutes && !ignoreFirstPageLoad) {
+              if (removeRegExp) {
+                _gaq('_trackPageview', getUrl());
+              } else {
+                _gaq('_trackPageview');
+              }
+            }
+          }
+
           return true;
         };
 
@@ -1074,11 +1087,8 @@
 
         // creates the Google Analytics tracker
         if (!delayScriptTag) {
-          if (analyticsJS) {
-            this._createAnalyticsScriptTag();
-          } else {
-            this._createScriptTag();
-          }
+          this._registerScriptTags();
+          this._registerTrackers();
         }
 
         // activates page tracking
@@ -1129,19 +1139,33 @@
           },
           getUrl: getUrl,
           /* DEPRECATED */
-          setCookieConfig: that._setCookieConfig,
+          setCookieConfig: function (config) {
+            that._log('warn', 'DEPRECATION WARNING: setCookieConfig method is deprecated. Please use tracker fields instead.');
+            return that._setCookieConfig.apply(that, arguments);
+          },
           /* DEPRECATED */
           getCookieConfig: function () {
+            that._log('warn', 'DEPRECATION WARNING: getCookieConfig method is deprecated. Please use tracker fields instead.');
             return cookieConfig;
           },
+          /* DEPRECATED */
           createAnalyticsScriptTag: function (config) {
+            that._log('warn', 'DEPRECATION WARNING: createAnalyticsScriptTag method is deprecated. Please use registerScriptTags and registerTrackers methods instead.');
             if (config) {
               cookieConfig = config;
             }
             return that._createAnalyticsScriptTag();
           },
+          /* DEPRECATED */
           createScriptTag: function () {
+            that._log('warn', 'DEPRECATION WARNING: createScriptTag method is deprecated. Please use registerScriptTags and registerTrackers methods instead.');
             return that._createScriptTag();
+          },
+          registerScriptTags: function () {
+            return that._registerScriptTags();
+          },
+          registerTrackers: function () {
+            return that._registerTrackers();
           },
           offline: function (mode) {
             if (mode === true && offlineMode === false) {

--- a/test/unit/offline-mode.js
+++ b/test/unit/offline-mode.js
@@ -45,7 +45,8 @@ describe('offline mode', function () {
 
       it('should send everything when script is added and reset to online', function () {
         inject(function (Analytics, $window) {
-          Analytics.createAnalyticsScriptTag();
+          Analytics.registerScriptTags();
+          Analytics.registerTrackers();
           Analytics.offline(false);
           expect(Analytics.log.length).toBe(3);
           expect(Analytics.log[0]).toEqual(['inject', '//www.google-analytics.com/analytics.js']);
@@ -134,7 +135,8 @@ describe('offline mode', function () {
       it('should send everything when script is added and reset to online', function () {
         inject(function (Analytics, $window) {
           $window._gaq.length = 0; // clear queue
-          Analytics.createScriptTag();
+          Analytics.registerScriptTags();
+          Analytics.registerTrackers();
           Analytics.offline(false);
           expect(Analytics.log.length).toBe(3);
           expect(Analytics.log[0]).toEqual(['inject', 'http://www.google-analytics.com/ga.js']);


### PR DESCRIPTION
Resolves #152 

* Backwards compatible change to split the create script methods along
separation of concern lines.
* registerScriptTags replaces both create*ScriptTag methods.
* registerTrackers performs all tracker setup.
* Added deprecation warnings to all deprecated methods.