### PR TITLE
fix unnecessary require of angular

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 /* globals define */
 (function (root, factory) {
   'use strict';
-  if (typeof define === 'function' && define.amd) {
+  if (typeof module !== 'undefined' && module.exports) {
+    if (typeof angular === 'undefined') {
+      factory(require('angular'));
+    } else {
+      factory(angular);
+    }
+    module.exports = 'angular-google-analytics';
+  } else if (typeof define === 'function' && define.amd) {
     define(['angular'], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory(require('angular'));
   } else {
     factory(root.angular);
   }


### PR DESCRIPTION
In my case I load `angular.js` from cdn before import of the module.
So main point is that you need to have additional checking to `require` the angular source.