### PR TITLE
Missing return value

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,7 +433,7 @@
 
           if (created === true) {
             that._log('warn', 'Script tags already created');
-            return;
+            return false;
           }
 
           if (disableAnalytics === true) {
@@ -502,7 +502,7 @@
         this._registerTrackers = function () {
           if (!accounts || accounts.length < 1) {
             that._log('warn', 'No accounts to register');
-            return;
+            return false;
           }
 
           //


### PR DESCRIPTION
When updating the typescript interface an inconsistency in the return value for the two methods. They return true at the end, but the intermediate returns imply void.

The meaning of the return value is not documented but I assume it means whether something was created and therefor the intermediate returns now return value.