### PR TITLE
Add trackPrefix to page object on events

### DIFF
--- a/index.js
+++ b/index.js
@@ -661,7 +661,7 @@
               angular.extend(opt_fieldObject, custom);
             }
             if (!angular.isDefined(opt_fieldObject.page)) {
-              opt_fieldObject.page = getUrl();
+              opt_fieldObject.page = trackPrefix + getUrl();
             }
             _gaMultipleTrackers(includeFn, 'send', 'event', category, action, label, value, opt_fieldObject);
           });

--- a/test/unit/universal-google-analytics.js
+++ b/test/unit/universal-google-analytics.js
@@ -122,6 +122,18 @@ describe('universal analytics', function () {
           expect(Analytics.log[2]).toEqual(['send', 'pageview', 'test-prefix']);
         });
       });
+
+      it('should send the url, including the prefix with each event', function() {
+        inject(function ($window) {
+          spyOn($window, 'ga');
+          inject(function (Analytics) {
+            Analytics.log.length = 0; // clear log
+            Analytics.trackEvent('test', 'action', 'label', 0);
+            expect(Analytics.log.length).toBe(1);
+            expect($window.ga).toHaveBeenCalledWith('send', 'event', 'test', 'action', 'label', 0, { page: 'test-prefix' });
+          });
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This is helpful when a view filters on a prefix and you want events specific to that view.

For instance, imagine setting environments on the same domain, differentiated by the prefix ('/internal/' and '/external/'), and you have views for internal and external filtered by the prefix. Now, events should be filtered to each view as well for accurate tracking.